### PR TITLE
Log configuration on proxy start

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ func main() { // nolint: gocyclo
 	defer logger.Sync() // nolint: errcheck
 
 	printURLs(conf.GetURLs())
+	zap.S().Debugw("Configuration", "config", conf)
 
 	if conf.UseMiddleProxy() {
 		zap.S().Infow("Use middle proxy connection to Telegram")


### PR DESCRIPTION
This has to simplify the debugging because usually, we do not know all options which user used to start mtg.