### PR TITLE
DualStack is deprecated

### DIFF
--- a/config/global_ips.go
+++ b/config/global_ips.go
@@ -21,7 +21,7 @@ func getGlobalIPv6() (net.IP, error) {
 }
 
 func fetchIP(network string) (net.IP, error) {
-	dialer := &net.Dialer{DualStack: false}
+	dialer := &net.Dialer{FallbackDelay: -1}
 	client := &http.Client{
 		Jar: nil,
 		Transport: &http.Transport{


### PR DESCRIPTION
```
	// DualStack previously enabled RFC 6555 Fast Fallback
	// support, also known as "Happy Eyeballs", in which IPv4 is
	// tried soon if IPv6 appears to be misconfigured and
	// hanging.
	//
	// Deprecated: Fast Fallback is enabled by default. To
	// disable, set FallbackDelay to a negative value.
	DualStack bool
```