### PR TITLE
Support proxy from environment variables.

### DIFF
--- a/telegram/dialer.go
+++ b/telegram/dialer.go
@@ -14,13 +14,13 @@ import (
 const telegramDialTimeout = 10 * time.Second
 
 type tgDialer struct {
-	net.Dialer
+	dialFunc func(network, address string) (net.Conn, error)
 
 	conf *config.Config
 }
 
 func (t *tgDialer) dial(addr string) (net.Conn, error) {
-	conn, err := t.Dialer.Dial("tcp", addr)
+	conn, err := t.dialFunc("tcp", addr)
 	if err != nil {
 		return nil, errors.Annotate(err, "Cannot connect to Telegram")
 	}

--- a/telegram/direct.go
+++ b/telegram/direct.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/juju/errors"
+	"golang.org/x/net/proxy"
 
 	"github.com/9seconds/mtg/config"
 	"github.com/9seconds/mtg/mtproto"
@@ -64,11 +65,12 @@ func (t *directTelegram) Init(connOpts *mtproto.ConnectionOpts,
 // NewDirectTelegram returns Telegram instance which connects directly
 // to Telegram bypassing middleproxies.
 func NewDirectTelegram(conf *config.Config) Telegram {
+	dialer := proxy.FromEnvironmentUsing(&net.Dialer{Timeout: telegramDialTimeout})
 	return &directTelegram{
 		baseTelegram: baseTelegram{
 			dialer: tgDialer{
-				Dialer: net.Dialer{Timeout: telegramDialTimeout},
-				conf:   conf,
+				dialFunc: dialer.Dial,
+				conf:     conf,
 			},
 			v4DefaultIdx: directV4DefaultIdx,
 			v6DefaultIdx: directV6DefaultIdx,

--- a/telegram/middle.go
+++ b/telegram/middle.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
+	"golang.org/x/net/proxy"
 
 	"github.com/9seconds/mtg/config"
 	"github.com/9seconds/mtg/mtproto"
@@ -114,12 +115,13 @@ func (t *middleTelegram) receiveRPCHandshakeResponse(conn wrappers.PacketReader,
 // NewMiddleTelegram creates new instance of Telegram which works with
 // middle proxies.
 func NewMiddleTelegram(conf *config.Config) Telegram {
+	dialer := proxy.FromEnvironmentUsing(&net.Dialer{Timeout: telegramDialTimeout})
 	tg := &middleTelegram{
 		middleTelegramCaller: middleTelegramCaller{
 			baseTelegram: baseTelegram{
 				dialer: tgDialer{
-					Dialer: net.Dialer{Timeout: telegramDialTimeout},
-					conf:   conf,
+					dialFunc: dialer.Dial,
+					conf:     conf,
 				},
 			},
 			httpClient: &http.Client{


### PR DESCRIPTION
Some contries ban tgproxy as well, so we must use some middle proxy. This PR make mtg be able to use another socks5 proxy to connect Telegram servers.