### PR TITLE
Make mtg go-gettable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ CC_BINARIES  := $(shell bash -c "echo -n $(APP_NAME)-{linux,freebsd,openbsd}-{38
 
 GOLANGCI_LINT_VERSION := v1.21.0
 
-VERSION_GO         := $(shell go version)
-VERSION_DATE       := $(shell date -Ru)
-VERSION_TAG        := $(shell git describe --tags --always)
-COMMON_BUILD_FLAGS := -ldflags="-s -w -X 'main.version=$(VERSION_TAG) ($(VERSION_GO)) [$(VERSION_DATE)]'"
+COMMON_BUILD_FLAGS := -ldflags="-s -w"
 
 MOD_ON  := env GO111MODULE=on
 MOD_OFF := env GO111MODULE=auto

--- a/antireplay/init.go
+++ b/antireplay/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/VictoriaMetrics/fastcache"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 var (

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 func Generate(secretType, hostname string) {

--- a/cli/proxy.go
+++ b/cli/proxy.go
@@ -8,16 +8,16 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"mtg/antireplay"
-	"mtg/config"
-	"mtg/faketls"
-	"mtg/hub"
-	"mtg/ntp"
-	"mtg/obfuscated2"
-	"mtg/proxy"
-	"mtg/stats"
-	"mtg/telegram"
-	"mtg/utils"
+	"github.com/9seconds/mtg/antireplay"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/faketls"
+	"github.com/9seconds/mtg/hub"
+	"github.com/9seconds/mtg/ntp"
+	"github.com/9seconds/mtg/obfuscated2"
+	"github.com/9seconds/mtg/proxy"
+	"github.com/9seconds/mtg/stats"
+	"github.com/9seconds/mtg/telegram"
+	"github.com/9seconds/mtg/utils"
 )
 
 func Proxy() error { // nolint: funlen

--- a/faketls/client_protocol.go
+++ b/faketls/client_protocol.go
@@ -11,14 +11,14 @@ import (
 	"sync"
 	"time"
 
-	"mtg/antireplay"
-	"mtg/config"
-	"mtg/conntypes"
-	"mtg/obfuscated2"
-	"mtg/protocol"
-	"mtg/stats"
-	"mtg/tlstypes"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/antireplay"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/obfuscated2"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/stats"
+	"github.com/9seconds/mtg/tlstypes"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 type ClientProtocol struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module mtg
+module github.com/9seconds/mtg
 
 go 1.13
 

--- a/hub/connection.go
+++ b/hub/connection.go
@@ -7,10 +7,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/mtproto"
-	"mtg/mtproto/rpc"
-	"mtg/protocol"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/mtproto"
+	"github.com/9seconds/mtg/mtproto/rpc"
+	"github.com/9seconds/mtg/protocol"
 )
 
 type connection struct {

--- a/hub/connection_list.go
+++ b/hub/connection_list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 type connectionList struct {

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"mtg/protocol"
+	"github.com/9seconds/mtg/protocol"
 )
 
 type hub struct {

--- a/hub/interface.go
+++ b/hub/interface.go
@@ -1,6 +1,6 @@
 package hub
 
-import "mtg/protocol"
+import "github.com/9seconds/mtg/protocol"
 
 type Interface interface {
 	Register(*protocol.TelegramRequest) (*ProxyConn, error)

--- a/hub/mux.go
+++ b/hub/mux.go
@@ -3,8 +3,8 @@ package hub
 import (
 	"context"
 
-	"mtg/conntypes"
-	"mtg/protocol"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/protocol"
 )
 
 type muxNewRequest struct {

--- a/hub/proxy_conn.go
+++ b/hub/proxy_conn.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"time"
 
-	"mtg/conntypes"
-	"mtg/mtproto/rpc"
-	"mtg/protocol"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/mtproto/rpc"
+	"github.com/9seconds/mtg/protocol"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ var (
 	runStatsNamespace = runCommand.Flag("stats-namespace",
 		"Which namespace to use for Prometheus.").
 		Envar("MTG_STATS_NAMESPACE").
-		Default("MTG").
+		Default("mtg").
 		String()
 	runStatsdAddress = runCommand.Flag("statsd-addr",
 		"Host:port of statsd server").

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	app = kingpin.New("MTG", "Simple MTPROTO proxy.")
+	app = kingpin.New("mtg", "Simple MTPROTO proxy.")
 
 	generateSecretCommand = app.Command("generate-secret",
 		"Generate new secret")

--- a/main.go
+++ b/main.go
@@ -7,15 +7,15 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	"mtg/cli"
-	"mtg/config"
-	"mtg/utils"
+	"github.com/9seconds/mtg/cli"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/utils"
 )
 
 var version = "dev" // this has to be set by build ld flags
 
 var (
-	app = kingpin.New("mtg", "Simple MTPROTO proxy.")
+	app = kingpin.New("MTG", "Simple MTPROTO proxy.")
 
 	generateSecretCommand = app.Command("generate-secret",
 		"Generate new secret")
@@ -66,7 +66,7 @@ var (
 	runStatsNamespace = runCommand.Flag("stats-namespace",
 		"Which namespace to use for Prometheus.").
 		Envar("MTG_STATS_NAMESPACE").
-		Default("mtg").
+		Default("MTG").
 		String()
 	runStatsdAddress = runCommand.Flag("statsd-addr",
 		"Host:port of statsd server").

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"math/rand"
 	"os"
+	"runtime/debug"
+	"strings"
 	"time"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -11,8 +13,6 @@ import (
 	"github.com/9seconds/mtg/config"
 	"github.com/9seconds/mtg/utils"
 )
-
-var version = "dev" // this has to be set by build ld flags
 
 var (
 	app = kingpin.New("MTG", "Simple MTPROTO proxy.")
@@ -114,7 +114,7 @@ var (
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
-	app.Version(version)
+	app.Version(getVersion())
 	app.HelpFlag.Short('h')
 
 	if err := utils.SetLimits(); err != nil {
@@ -152,4 +152,27 @@ func main() {
 			cli.Fatal(err)
 		}
 	}
+}
+
+func getVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		builder := strings.Builder{}
+		version := info.Main.Version
+
+		if version == "(devel)" {
+			version = "dev"
+		}
+
+		builder.WriteString(version)
+
+		if info.Main.Sum != "" {
+			builder.WriteString(" (checksum: ")
+			builder.WriteString(info.Main.Sum)
+			builder.WriteRune(')')
+		}
+
+		return builder.String()
+	}
+
+	return "dev"
 }

--- a/mtproto/protocol.go
+++ b/mtproto/protocol.go
@@ -3,12 +3,12 @@ package mtproto
 import (
 	"fmt"
 
-	"mtg/conntypes"
-	"mtg/mtproto/rpc"
-	"mtg/protocol"
-	"mtg/telegram"
-	"mtg/wrappers/packet"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/mtproto/rpc"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/telegram"
+	"github.com/9seconds/mtg/wrappers/packet"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 func TelegramProtocol(req *protocol.TelegramRequest) (conntypes.PacketReadWriteCloser, error) {

--- a/mtproto/rpc/proxy_response.go
+++ b/mtproto/rpc/proxy_response.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type ProxyResponseType uint8

--- a/obfuscated2/client_protocol.go
+++ b/obfuscated2/client_protocol.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"time"
 
-	"mtg/antireplay"
-	"mtg/config"
-	"mtg/conntypes"
-	"mtg/protocol"
-	"mtg/stats"
-	"mtg/utils"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/antireplay"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/stats"
+	"github.com/9seconds/mtg/utils"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 const clientProtocolHandshakeTimeout = 10 * time.Second

--- a/obfuscated2/telegram_protocol.go
+++ b/obfuscated2/telegram_protocol.go
@@ -4,11 +4,11 @@ import (
 	"crypto/rand"
 	"fmt"
 
-	"mtg/conntypes"
-	"mtg/protocol"
-	"mtg/telegram"
-	"mtg/utils"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/telegram"
+	"github.com/9seconds/mtg/utils"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 func TelegramProtocol(req *protocol.TelegramRequest) (conntypes.StreamReadWriteCloser, error) {

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -1,6 +1,6 @@
 package protocol
 
-import "mtg/conntypes"
+import "github.com/9seconds/mtg/conntypes"
 
 type ClientProtocol interface {
 	Handshake(conntypes.StreamReadWriteCloser) (conntypes.StreamReadWriteCloser, error)

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -5,7 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type TelegramRequest struct {

--- a/proxy/direct.go
+++ b/proxy/direct.go
@@ -6,9 +6,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/obfuscated2"
-	"mtg/protocol"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/obfuscated2"
+	"github.com/9seconds/mtg/protocol"
 )
 
 const directPipeBufferSize = 1024 * 1024

--- a/proxy/middle.go
+++ b/proxy/middle.go
@@ -5,9 +5,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/protocol"
-	"mtg/wrappers/packetack"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/wrappers/packetack"
 )
 
 func middleConnection(request *protocol.TelegramRequest) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,12 +6,12 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/config"
-	"mtg/conntypes"
-	"mtg/protocol"
-	"mtg/stats"
-	"mtg/utils"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/protocol"
+	"github.com/9seconds/mtg/stats"
+	"github.com/9seconds/mtg/utils"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 type Proxy struct {

--- a/stats/interfaces.go
+++ b/stats/interfaces.go
@@ -3,7 +3,7 @@ package stats
 import (
 	"net"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type IngressTrafficInterface interface {

--- a/stats/multi_stats.go
+++ b/stats/multi_stats.go
@@ -3,7 +3,7 @@ package stats
 import (
 	"net"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type multiStats []Interface

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"net/http"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 var Stats Interface

--- a/stats/stats_prometheus.go
+++ b/stats/stats_prometheus.go
@@ -8,8 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"mtg/config"
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type statsPrometheus struct {

--- a/stats/stats_statsd.go
+++ b/stats/stats_statsd.go
@@ -11,8 +11,8 @@ import (
 	statsd "github.com/smira/go-statsd"
 	"go.uber.org/zap"
 
-	"mtg/config"
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 var (

--- a/telegram/api/addresses.go
+++ b/telegram/api/addresses.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 const (

--- a/telegram/api/api.go
+++ b/telegram/api/api.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	apiUserAgent   = "mtg"
+	apiUserAgent   = "github.com/9seconds/mtg"
 	apiHTTPTimeout = 30 * time.Second
 )
 

--- a/telegram/base.go
+++ b/telegram/base.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"net"
 
-	"mtg/conntypes"
-	"mtg/utils"
-	"mtg/wrappers/stream"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/utils"
+	"github.com/9seconds/mtg/wrappers/stream"
 )
 
 type baseTelegram struct {

--- a/telegram/direct.go
+++ b/telegram/direct.go
@@ -1,6 +1,6 @@
 package telegram
 
-import "mtg/conntypes"
+import "github.com/9seconds/mtg/conntypes"
 
 const (
 	directV4DefaultIdx conntypes.DC = 1

--- a/telegram/interfaces.go
+++ b/telegram/interfaces.go
@@ -1,6 +1,6 @@
 package telegram
 
-import "mtg/conntypes"
+import "github.com/9seconds/mtg/conntypes"
 
 type Telegram interface {
 	Dial(conntypes.DC, conntypes.ConnectionProtocol) (conntypes.StreamReadWriteCloser, error)

--- a/telegram/middle.go
+++ b/telegram/middle.go
@@ -7,8 +7,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/telegram/api"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/telegram/api"
 )
 
 const middleTelegramBackgroundUpdateEvery = time.Hour

--- a/tlstypes/client_hello.go
+++ b/tlstypes/client_hello.go
@@ -6,8 +6,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"mtg/config"
-	"mtg/utils"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/utils"
 )
 
 type ClientHello struct {

--- a/tlstypes/handshake.go
+++ b/tlstypes/handshake.go
@@ -3,7 +3,7 @@ package tlstypes
 import (
 	"bytes"
 
-	"mtg/utils"
+	"github.com/9seconds/mtg/utils"
 )
 
 type Handshake struct {

--- a/tlstypes/server_hello.go
+++ b/tlstypes/server_hello.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/crypto/curve25519"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 type ServerHello struct {

--- a/utils/init_tcp.go
+++ b/utils/init_tcp.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"mtg/config"
+	"github.com/9seconds/mtg/config"
 )
 
 func InitTCP(conn net.Conn) error {

--- a/wrappers/packet/mtproto_frame.go
+++ b/wrappers/packet/mtproto_frame.go
@@ -12,7 +12,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 const (

--- a/wrappers/packetack/client_abridged.go
+++ b/wrappers/packetack/client_abridged.go
@@ -8,8 +8,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/utils"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/utils"
 )
 
 const (

--- a/wrappers/packetack/client_intermediate.go
+++ b/wrappers/packetack/client_intermediate.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 const clientIntermediateQuickAckLength = 0x80000000

--- a/wrappers/packetack/client_intermediate_secure.go
+++ b/wrappers/packetack/client_intermediate_secure.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type wrapperClientIntermediateSecure struct {

--- a/wrappers/packetack/proxy.go
+++ b/wrappers/packetack/proxy.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"net"
 
-	"mtg/config"
-	"mtg/conntypes"
-	"mtg/hub"
-	"mtg/mtproto/rpc"
-	"mtg/protocol"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/hub"
+	"github.com/9seconds/mtg/mtproto/rpc"
+	"github.com/9seconds/mtg/protocol"
 )
 
 type wrapperProxy struct {

--- a/wrappers/stream/base.go
+++ b/wrappers/stream/base.go
@@ -3,7 +3,7 @@ package stream
 import (
 	"net"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 func NewClientConn(parent net.Conn, connID conntypes.ConnID) conntypes.StreamReadWriteCloser {

--- a/wrappers/stream/blockcipher.go
+++ b/wrappers/stream/blockcipher.go
@@ -9,8 +9,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/utils"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/utils"
 )
 
 type wrapperBlockCipher struct {

--- a/wrappers/stream/conn.go
+++ b/wrappers/stream/conn.go
@@ -7,8 +7,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/config"
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/config"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type connPurpose uint8

--- a/wrappers/stream/ctx.go
+++ b/wrappers/stream/ctx.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type wrapperCtx struct {

--- a/wrappers/stream/faketls.go
+++ b/wrappers/stream/faketls.go
@@ -8,8 +8,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/tlstypes"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/tlstypes"
 )
 
 type wrapperFakeTLS struct {

--- a/wrappers/stream/mtproto_cipher.go
+++ b/wrappers/stream/mtproto_cipher.go
@@ -9,9 +9,9 @@ import (
 	"encoding/binary"
 	"net"
 
-	"mtg/conntypes"
-	"mtg/mtproto/rpc"
-	"mtg/utils"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/mtproto/rpc"
+	"github.com/9seconds/mtg/utils"
 )
 
 type mtprotoCipherPurpose uint8

--- a/wrappers/stream/obfuscated2.go
+++ b/wrappers/stream/obfuscated2.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type wrapperObfuscated2 struct {

--- a/wrappers/stream/rewind.go
+++ b/wrappers/stream/rewind.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 type ReadWriteCloseRewinder interface {

--- a/wrappers/stream/stats_telegram.go
+++ b/wrappers/stream/stats_telegram.go
@@ -7,8 +7,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/stats"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/stats"
 )
 
 type wrapperTelegramStats struct {

--- a/wrappers/stream/stats_traffic.go
+++ b/wrappers/stream/stats_traffic.go
@@ -6,8 +6,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
-	"mtg/stats"
+	"github.com/9seconds/mtg/conntypes"
+	"github.com/9seconds/mtg/stats"
 )
 
 type wrapperTrafficStats struct {

--- a/wrappers/stream/timeout.go
+++ b/wrappers/stream/timeout.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"mtg/conntypes"
+	"github.com/9seconds/mtg/conntypes"
 )
 
 const (


### PR DESCRIPTION
This fixes https://github.com/9seconds/mtg/issues/114

This PR is going to contain 3 commits. Every commit address one of the mentioned sub-issues:

- [x] make mtg go-gettable
- [ ] make tag based on semver
- [x] use https://godoc.org/runtime/debug#ReadBuildInfo instead of ldflags