### PR TITLE
Add possibility to define your own ntp servers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,8 @@ const (
 
 	OptionTypeMultiplexPerConnection
 
+	OptionTypeNTPServers
+
 	OptionTypeSecret
 	OptionTypeAdtag
 )
@@ -96,6 +98,7 @@ type Config struct {
 	Verbose    bool       `json:"verbose"`
 	SecretMode SecretMode `json:"secret_mode"`
 	PreferIP   PreferIP   `json:"prefer_ip"`
+	NTPServers []string   `json:"ntp_servers"`
 
 	Secret []byte `json:"secret"`
 	AdTag  []byte `json:"adtag"`
@@ -165,6 +168,11 @@ func Init(options ...Opt) error { // nolint: gocyclo, funlen
 			C.AntiReplayMaxSize = int(opt.Value.(units.Base2Bytes))
 		case OptionTypeMultiplexPerConnection:
 			C.MultiplexPerConnection = int(opt.Value.(uint))
+		case OptionTypeNTPServers:
+			C.NTPServers = opt.Value.([]string)
+			if len(C.NTPServers) == 0 {
+				return errors.New("ntp server list is empty")
+			}
 		case OptionTypeSecret:
 			C.Secret = opt.Value.([]byte)
 		case OptionTypeAdtag:

--- a/main.go
+++ b/main.go
@@ -115,6 +115,11 @@ var (
 		Envar("MTG_MULTIPLEX_PERCONNECTION").
 		Default("50").
 		Uint()
+	runNTPServers = runCommand.Flag("ntp-server",
+		"A list of NTP servers to use.").
+		Envar("MTG_NTP_SERVERS").
+		Default("0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org").
+		Strings()
 	runSecret = runCommand.Arg("secret", "Secret of this proxy.").Required().HexBytes()
 	runAdtag  = runCommand.Arg("adtag", "ADTag of the proxy.").HexBytes()
 )
@@ -149,6 +154,7 @@ func main() {
 			config.Opt{Option: config.OptionTypeCloakPort, Value: *runTLSCloakPort},
 			config.Opt{Option: config.OptionTypeAntiReplayMaxSize, Value: *runAntiReplayMaxSize},
 			config.Opt{Option: config.OptionTypeMultiplexPerConnection, Value: *runMultiplexPerConnection},
+			config.Opt{Option: config.OptionTypeNTPServers, Value: *runNTPServers},
 			config.Opt{Option: config.OptionTypeSecret, Value: *runSecret},
 			config.Opt{Option: config.OptionTypeAdtag, Value: *runAdtag},
 		)

--- a/ntp/ntp.go
+++ b/ntp/ntp.go
@@ -7,20 +7,15 @@ import (
 
 	"github.com/beevik/ntp"
 	"go.uber.org/zap"
+
+	"github.com/9seconds/mtg/config"
 )
 
 const autoUpdatePeriod = time.Minute
 
-var ntpEndpoints = [...]string{
-	"0.pool.ntp.org",
-	"1.pool.ntp.org",
-	"2.pool.ntp.org",
-	"3.pool.ntp.org",
-}
-
 // Fetch fetches the data on time drift.
 func Fetch() (time.Duration, error) {
-	url := ntpEndpoints[rand.Intn(len(ntpEndpoints))]
+	url := config.C.NTPServers[rand.Intn(len(config.C.NTPServers))]
 
 	resp, err := ntp.Query(url)
 	if err != nil {


### PR DESCRIPTION
This closed https://github.com/9seconds/mtg/issues/135

This PR adds a new option, `--ntp-server` which allows you to use your own ntp servers. By default it still uses a global pool.