### PR TITLE
fix DOHIP config to allow ipv6 and domains

### DIFF
--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -37,7 +37,7 @@ func makeLogger(conf *config.Config) mtglib.Logger {
 func makeNetwork(conf *config.Config, version string) (mtglib.Network, error) {
 	tcpTimeout := conf.Network.Timeout.TCP.Get(network.DefaultTimeout)
 	httpTimeout := conf.Network.Timeout.HTTP.Get(network.DefaultHTTPTimeout)
-	dohIP := conf.Network.DOHIP.Get(net.ParseIP(network.DefaultDOHHostname)).String()
+	dohIP := conf.Network.DOHIP.Get(network.DefaultDOHHostname)
 	bufferSize := conf.TCPBuffer.Get(network.DefaultBufferSize)
 	userAgent := "mtg/" + version
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 			HTTP TypeDuration `json:"http"`
 			Idle TypeDuration `json:"idle"`
 		} `json:"timeout"`
-		DOHIP   TypeIP         `json:"dohIp"`
+		DOHIP   TypeURLHost    `json:"dohIp"`
 		Proxies []TypeProxyURL `json:"proxies"`
 	} `json:"network"`
 	Stats struct {

--- a/internal/config/type_urlhost.go
+++ b/internal/config/type_urlhost.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type TypeURLHost struct {
+	Value string
+}
+
+func (t *TypeURLHost) Set(value string) error {
+
+	if value == "" {
+		return fmt.Errorf("value empty")
+	}
+
+	testUrl := fmt.Sprintf("https://%s/dns-query", value)
+	p, err := url.Parse(testUrl)
+	if err != nil {
+		return err
+	}
+
+	if p.Host != value {
+		return fmt.Errorf("value is not a valid url host: %s", value)
+	}
+
+	t.Value = value
+
+	return nil
+}
+
+func (t TypeURLHost) Get(defaultValue string) string {
+	if t.Value == "" {
+		return defaultValue
+	}
+
+	return t.Value
+}
+
+func (t *TypeURLHost) UnmarshalText(data []byte) error {
+	return t.Set(string(data))
+}
+
+func (t TypeURLHost) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+func (t TypeURLHost) String() string {
+	return t.Value
+}

--- a/internal/config/type_urlhost_test.go
+++ b/internal/config/type_urlhost_test.go
@@ -1,0 +1,87 @@
+package config_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/9seconds/mtg/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TypeURLHostTestStruct struct {
+	Value config.TypeURLHost `json:"value"`
+}
+
+type TypeURLHostTestSuite struct {
+	suite.Suite
+}
+
+func (suite *TypeURLHostTestSuite) TestUnmarshalFail() {
+	testData := []string{
+		"",
+	}
+
+	for _, v := range testData {
+		data, err := json.Marshal(map[string]string{
+			"value": v,
+		})
+		suite.NoError(err)
+
+		suite.T().Run(v, func(t *testing.T) {
+			assert.Error(t, json.Unmarshal(data, &TypeURLHostTestStruct{}))
+		})
+	}
+}
+
+func (suite *TypeURLHostTestSuite) TestUnmarshalOk() {
+	testData := []string{
+		"dns.google",
+		"cloudflare-dns.com",
+		"9.9.9.9",
+		"127.0.0.1:80",
+		"10.0.0.10:6553",
+		"[2001:1234::1]:6553",
+		"[::1]:80",
+	}
+
+	for _, v := range testData {
+		value := v
+
+		data, err := json.Marshal(map[string]string{
+			"value": v,
+		})
+		suite.NoError(err)
+
+		suite.T().Run(v, func(t *testing.T) {
+			testStruct := &TypeURLHostTestStruct{}
+			assert.NoError(t, json.Unmarshal(data, testStruct))
+			assert.Equal(t, value, testStruct.Value.Value)
+		})
+	}
+}
+
+func (suite *TypeURLHostTestSuite) TestMarshalOk() {
+	testStruct := TypeURLHostTestStruct{
+		Value: config.TypeURLHost{
+			Value: "127.0.0.1:8000",
+		},
+	}
+
+	data, err := json.Marshal(testStruct)
+	suite.NoError(err)
+	suite.JSONEq(`{"value": "127.0.0.1:8000"}`, string(data))
+}
+
+func (suite *TypeURLHostTestSuite) TestGet() {
+	value := config.TypeURLHost{}
+	suite.Equal("127.0.0.1:9000", value.Get("127.0.0.1:9000"))
+
+	value.Value = "127.0.0.1:80"
+	suite.Equal("127.0.0.1:80", value.Get("127.0.0.1:9000"))
+}
+
+func TestTypeURLHost(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &TypeURLHostTestSuite{})
+}

--- a/network/network.go
+++ b/network/network.go
@@ -129,10 +129,6 @@ func NewNetwork(dialer Dialer,
 		httpTimeout = DefaultHTTPTimeout
 	}
 
-	if net.ParseIP(dohHostname) == nil {
-		return nil, fmt.Errorf("hostname %s should be IP address", dohHostname)
-	}
-
 	return &network{
 		dialer:      dialer,
 		httpTimeout: httpTimeout,


### PR DESCRIPTION
## Allow Domain

The `doh-ip` config item was designed only for ipv4 IP address, but however DOH queries are not only IPs, it can be a  domain.  According to rfc8484, the request is a http POST request to an address like `https://dnsserver.example.net/dns-query`

This is how the `babolivier/go-doh-client` implimented to use the Host value:

https://github.com/babolivier/go-doh-client/blob/a76cff4cb8b631ae9cc87d980d379694115c3862/http.go#L14-L21

Thus our `doh-ip` should allow the form of domain servers, like `dns.google`, ipv6 servers `[2606:4700:4700::64]`, or a customed server like `127.0.0.1:7777`.

## Allow IPv6 

In the original implimentation, user cannot use an IPv6 server:

if config `doh-ip = 2606:4700:4700::64`，the config valids but in the DOH resolve they construct the POST to `http://2606:4700:4700::64/dns-query`, it's an invalid URL, DOH fails.

if config `doh-ip = [2606:4700:4700::64]`, the way url constructs, but our program don't reconizes it as an IP. DOH fail.

## Correct Examples

After the PR, this config should all be working 
```
doh-ip = "[2606:4700:4700::1111]"
doh-ip = "cloudflare-dns.com"
doh-ip = "cloudflare-dns.com:443"
doh-ip = "9.9.9.9:443"
doh-ip = "dns.google"
doh-ip = "dns.google:443"
```