### PR TITLE
Telegram bridge over I2P.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/eyedeekay/sam3 v0.32.32 // indirect
 	github.com/gotd/ige v0.1.5 // indirect
 	github.com/gotd/xor v0.1.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/eyedeekay/sam3 v0.32.32 h1:9Ea1Ere5O8Clx8zYxKnvhrWy7R96Q4FvxlPskYf8VW0=
+github.com/eyedeekay/sam3 v0.32.32/go.mod h1:qRA9KIIVxbrHlkj+ZB+OoxFGFgdKeGp1vSgPw26eOVU=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/internal/config/type_hostport.go
+++ b/internal/config/type_hostport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 )
 
 type TypeHostPort struct {
@@ -13,6 +14,12 @@ type TypeHostPort struct {
 }
 
 func (t *TypeHostPort) Set(value string) error {
+	if strings.HasSuffix(value, ".i2p") {
+		t.Port = uint(0)
+		t.Host = value
+		t.Value = value
+		return nil
+	}
 	host, port, err := net.SplitHostPort(value)
 	if err != nil {
 		return fmt.Errorf("incorrect host:port value (%v): %w", value, err)

--- a/internal/utils/net_listener.go
+++ b/internal/utils/net_listener.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/9seconds/mtg/v2/network"
+	sam "github.com/eyedeekay/sam3/helper"
 )
 
 type Listener struct {
@@ -27,6 +29,15 @@ func (l Listener) Accept() (net.Conn, error) {
 }
 
 func NewListener(bindTo string, bufferSize int) (net.Listener, error) {
+	if strings.HasSuffix(bindTo, ".i2p") {
+		base, err := sam.I2PListener(bindTo, "127.0.0.1:7656", bindTo)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build a base I2P listener: %w", err)
+		}
+		return Listener{
+			Listener: base,
+		}, nil
+	}
 	base, err := net.Listen("tcp", bindTo)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build a base listener: %w", err)


### PR DESCRIPTION
This adds support for running a Telegram MTProto bridge over the I2P anonymous network. This support is self-configuring using our Simple Anonymous Messaging API and results in the MTProto bridge being available on an I2P Base32 address(sort of like our version of an `.onion` site). It can be enabled by setting `bind-to` to an address ending in `.i2p`. I2P has a petnaming service which can be used to alias the long, random Base32 address to the shorter, human-readable the `bind-to` address to make things easier for the users. This argument determines the location of the I2P private and public keys, for instance if the `bind-to` is "telegram.i2p` the keys will be created at `telegram.i2p.i2p.private` and `telegram.i2p.i2p.public.txt` in the working directory. `telegram.i2p.i2p.public.txt` contains the public address. This self-configuring support makes it easier for users to deploy I2P MTProto proxies with minimal configuration.