### PR TITLE
Add iplist_size metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Here goes a list of metrics with their types but without a prefix.
 | client_connections          | gauge   | `ip_family`                      | Count of processing client connections.                                                    |
 | telegram_connections        | gauge   | `telegram_ip`, `dc`              | Count of connections to Telegram servers.                                                  |
 | domain_fronting_connections | gauge   | `ip_family`                      | Count of connections to fronting domain.                                                   |
+| iplist_size                 | gauge   | `ip_list`                        | A size of either allowlist or blocklist in use.                                            |
 | telegram_traffic            | counter | `telegram_ip`, `dc`, `direction` | Count of bytes, transmitted to/from Telegram.                                              |
 | domain_fronting_traffic     | counter | `direction`                      | Count of bytes, transmitted to/from fronting domain.                                       |
 | domain_fronting             | counter | –                                | Count of domain fronting events.                                                           |
@@ -398,3 +399,4 @@ Tag meaning:
 | dc          |                            | A number of the Telegram DC for a connection. |
 | telegram_ip |                            | IP address of the Telegram server.            |
 | direction   | `to_client`, `from_client` | A direction of the traffic flow.              |
+| ip_list     | `allowlist`, `blocklist`   | A type of the IP list.                        |

--- a/events/event_stream.go
+++ b/events/event_stream.go
@@ -102,6 +102,8 @@ func eventStreamProcessor(ctx context.Context, eventChan <-chan mtglib.Event, ob
 				observer.EventConcurrencyLimited(typedEvt)
 			case mtglib.EventReplayAttack:
 				observer.EventReplayAttack(typedEvt)
+			case mtglib.EventIPListSize:
+				observer.EventIPListSize(typedEvt)
 			}
 		}
 	}

--- a/events/event_stream_test.go
+++ b/events/event_stream_test.go
@@ -204,6 +204,27 @@ func (suite *EventStreamTestSuite) TestEventReplayAttack() {
 	time.Sleep(100 * time.Millisecond)
 }
 
+func (suite *EventStreamTestSuite) TestEventIPListSize() {
+	evt := mtglib.NewEventIPListSize(10, true)
+
+	for _, v := range []*ObserverMock{suite.observerMock1, suite.observerMock2} {
+		v.
+			On("EventIPListSize", mock.Anything).
+			Once().
+			Run(func(args mock.Arguments) {
+				caught, ok := args.Get(0).(mtglib.EventIPListSize)
+
+				suite.True(ok)
+				suite.Equal(evt.Timestamp(), caught.Timestamp())
+				suite.Equal(evt.Size, caught.Size)
+				suite.Equal(evt.IsBlockList, caught.IsBlockList)
+			})
+	}
+
+	suite.stream.Send(suite.ctx, evt)
+	time.Sleep(100 * time.Millisecond)
+}
+
 func (suite *EventStreamTestSuite) TearDownTest() {
 	suite.stream.Shutdown()
 	suite.ctxCancel()

--- a/events/init.go
+++ b/events/init.go
@@ -53,6 +53,9 @@ type Observer interface {
 	// EventReplayAttack reacts on incoming mtglib.EventReplayAttack event.
 	EventReplayAttack(mtglib.EventReplayAttack)
 
+	// EventIPListSize reacts on incoming mtglib.EventIPListSize
+	EventIPListSize(mtglib.EventIPListSize)
+
 	// Shutdown stop observer. Default event stream guarantees:
 	//   1. If shutdown is executed, it is executed only once
 	//   2. Observer won't receieve any new message after this

--- a/events/init_test.go
+++ b/events/init_test.go
@@ -41,6 +41,10 @@ func (o *ObserverMock) EventReplayAttack(evt mtglib.EventReplayAttack) {
 	o.Called(evt)
 }
 
+func (o *ObserverMock) EventIPListSize(evt mtglib.EventIPListSize) {
+	o.Called(evt)
+}
+
 func (o *ObserverMock) Shutdown() {
 	o.Called()
 }

--- a/events/multi_observer.go
+++ b/events/multi_observer.go
@@ -130,6 +130,21 @@ func (m multiObserver) EventReplayAttack(evt mtglib.EventReplayAttack) {
 	wg.Wait()
 }
 
+func (m multiObserver) EventIPListSize(evt mtglib.EventIPListSize) {
+	wg := &sync.WaitGroup{}
+	wg.Add(len(m.observers))
+
+	for _, v := range m.observers {
+		go func(obs Observer) {
+			defer wg.Done()
+
+			obs.EventIPListSize(evt)
+		}(v)
+	}
+
+	wg.Wait()
+}
+
 func (m multiObserver) Shutdown() {
 	for _, v := range m.observers {
 		v.Shutdown()

--- a/events/noop.go
+++ b/events/noop.go
@@ -25,6 +25,7 @@ func (n noopObserver) EventFinish(_ mtglib.EventFinish)                         
 func (n noopObserver) EventConcurrencyLimited(_ mtglib.EventConcurrencyLimited) {}
 func (n noopObserver) EventIPBlocklisted(_ mtglib.EventIPBlocklisted)           {}
 func (n noopObserver) EventReplayAttack(_ mtglib.EventReplayAttack)             {}
+func (n noopObserver) EventIPListSize(_ mtglib.EventIPListSize)                 {}
 func (n noopObserver) Shutdown()                                                {}
 
 // NewNoopObserver creates an observer which discards each message.

--- a/events/noop_test.go
+++ b/events/noop_test.go
@@ -27,6 +27,7 @@ func (suite *NoopTestSuite) SetupSuite() {
 		"concurrency-limited": mtglib.NewEventConcurrencyLimited(),
 		"ip-blacklisted":      mtglib.NewEventIPBlocklisted(net.ParseIP("10.0.0.10")),
 		"replay-attack":       mtglib.NewEventReplayAttack("connID"),
+		"ip-list-size":        mtglib.NewEventIPListSize(10, true),
 	}
 	suite.ctx = context.Background()
 }
@@ -65,6 +66,8 @@ func (suite *NoopTestSuite) TestObserver() {
 				observer.EventIPBlocklisted(typedEvt)
 			case mtglib.EventReplayAttack:
 				observer.EventReplayAttack(typedEvt)
+			case mtglib.EventIPListSize:
+				observer.EventIPListSize(typedEvt)
 			}
 		})
 	}

--- a/example.config.toml
+++ b/example.config.toml
@@ -170,7 +170,7 @@ download-concurrency = 2
 # You can provider links here (starts with https:// or http://) or
 # path to a local file, but in this case it should be absolute.
 urls = [
-    # "https://iplists.firehol.org/files/firehol_level1.netset",
+    "https://iplists.firehol.org/files/firehol_level1.netset",
     # "/local.file"
 ]
 # How often do we need to update a blocklist set.

--- a/ipblocklist/firehol_test.go
+++ b/ipblocklist/firehol_test.go
@@ -67,7 +67,8 @@ func (suite *FireholTestSuite) TearDownSuite() {
 func (suite *FireholTestSuite) TestLocalFail() {
 	blocklist, err := ipblocklist.NewFirehol(logger.NewNoopLogger(),
 		suite.networkMock, 2,
-		nil, []string{filepath.Join("testdata", "broken_ipset.ipset")})
+		nil, []string{filepath.Join("testdata", "broken_ipset.ipset")},
+		nil)
 
 	suite.NoError(err)
 
@@ -85,7 +86,8 @@ func (suite *FireholTestSuite) TestLocalFail() {
 func (suite *FireholTestSuite) TestLocalOk() {
 	blocklist, err := ipblocklist.NewFirehol(logger.NewNoopLogger(),
 		suite.networkMock, 2,
-		nil, []string{filepath.Join("testdata", "good_ipset.ipset")})
+		nil, []string{filepath.Join("testdata", "good_ipset.ipset")},
+		nil)
 
 	suite.NoError(err)
 
@@ -103,7 +105,7 @@ func (suite *FireholTestSuite) TestLocalOk() {
 func (suite *FireholTestSuite) TestRemoteFail() {
 	blocklist, err := ipblocklist.NewFirehol(logger.NewNoopLogger(),
 		suite.networkMock, 2,
-		[]string{"https://google.com"}, nil)
+		[]string{"https://google.com"}, nil, nil)
 
 	suite.NoError(err)
 
@@ -127,7 +129,7 @@ func (suite *FireholTestSuite) TestMixed() {
 			suite.httpServer.URL,
 		}, []string{
 			filepath.Join("testdata", "good_ipset.ipset"),
-		})
+		}, nil)
 
 	suite.NoError(err)
 

--- a/mtglib/events.go
+++ b/mtglib/events.go
@@ -92,6 +92,15 @@ type EventReplayAttack struct {
 	eventBase
 }
 
+// EventIPListSize is emitted when mtg updates a contents of the ip lists:
+// allowlist or blocklist.
+type EventIPListSize struct {
+	eventBase
+
+	Size        int
+	IsBlockList bool
+}
+
 // NewEventStart creates a new EventStart event.
 func NewEventStart(streamID string, remoteIP net.IP) EventStart {
 	return EventStart{
@@ -174,5 +183,16 @@ func NewEventReplayAttack(streamID string) EventReplayAttack {
 			timestamp: time.Now(),
 			streamID:  streamID,
 		},
+	}
+}
+
+// NewEventIPListSize creates a new EventIPListSize event.
+func NewEventIPListSize(size int, isBlockList bool) EventIPListSize {
+	return EventIPListSize{
+		eventBase: eventBase{
+			timestamp: time.Now(),
+		},
+		Size:        size,
+		IsBlockList: isBlockList,
 	}
 }

--- a/mtglib/events_test.go
+++ b/mtglib/events_test.go
@@ -69,6 +69,15 @@ func (suite *EventsTestSuite) TestEventReplayAttack() {
 	suite.WithinDuration(time.Now(), evt.Timestamp(), 10*time.Millisecond)
 }
 
+func (suite *EventsTestSuite) TestEventIPListSize() {
+	evt := mtglib.NewEventIPListSize(10, false)
+
+	suite.Empty(evt.StreamID())
+	suite.WithinDuration(time.Now(), evt.Timestamp(), 10*time.Millisecond)
+	suite.Equal(10, evt.Size)
+	suite.False(evt.IsBlockList)
+}
+
 func TestEvents(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &EventsTestSuite{})

--- a/stats/init.go
+++ b/stats/init.go
@@ -89,6 +89,13 @@ const (
 	//     Type: counter
 	MetricReplayAttacks = "replay_attacks"
 
+	// MetricIPListSize defines a metric for the size of the the ip list.
+	//
+	//     Type: gauge
+	//     Tags:
+	//       ip_list | 'allowlist' or 'blocklist'
+	MetricIPListSize = "iplist_size"
+
 	// TagIPFamily defines a name of the 'ip_family' tag and all values.
 	TagIPFamily = "ip_family"
 
@@ -114,4 +121,13 @@ const (
 	// TagDirectionFromClient defines that traffic is sent from a client to
 	// Telegram.
 	TagDirectionFromClient = "from_client"
+
+	// TagIPList defines a name of the 'ip_list' and all values.
+	TagIPList = "ip_list"
+
+	// TagIPListAllow defines a value of 'ip_list' of allowlist.
+	TagIPListAllow = "allowlist"
+
+	// TagIPListBlock defines a value of 'ip_list' of blocklist.
+	TagIPListBlock = "blocklist"
 )

--- a/stats/prometheus_test.go
+++ b/stats/prometheus_test.go
@@ -169,6 +169,18 @@ func (suite *PrometheusTestSuite) TestEventReplayAttack() {
 	suite.Contains(data, `mtg_replay_attacks 1`)
 }
 
+func (suite *PrometheusTestSuite) TestEventIPListSize() {
+	suite.prometheus.EventIPListSize(mtglib.NewEventIPListSize(10, false))
+	suite.prometheus.EventIPListSize(mtglib.NewEventIPListSize(3, true))
+
+	time.Sleep(100 * time.Millisecond)
+
+	data, err := suite.Get()
+	suite.NoError(err)
+	suite.Contains(data, `mtg_iplist_size{ip_list="allowlist"} 10`)
+	suite.Contains(data, `mtg_iplist_size{ip_list="blocklist"} 3`)
+}
+
 func TestPrometheus(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &PrometheusTestSuite{})

--- a/stats/statsd.go
+++ b/stats/statsd.go
@@ -121,6 +121,15 @@ func (s statsdProcessor) EventReplayAttack(_ mtglib.EventReplayAttack) {
 	s.client.Incr(MetricReplayAttacks, 1)
 }
 
+func (s statsdProcessor) EventIPListSize(evt mtglib.EventIPListSize) {
+	tag := TagIPListBlock
+	if !evt.IsBlockList {
+		tag = TagIPListAllow
+	}
+
+	s.client.Gauge(MetricIPListSize, int64(evt.Size), statsd.StringTag(TagIPList, tag))
+}
+
 func (s statsdProcessor) Shutdown() {
 	events := make([]mtglib.EventFinish, 0, len(s.streams))
 

--- a/stats/statsd_test.go
+++ b/stats/statsd_test.go
@@ -196,6 +196,22 @@ func (suite *StatsdTestSuite) TestEventReplayAttack() {
 	suite.Equal("mtg.replay_attacks:1|c", suite.statsdServer.String())
 }
 
+func (suite *StatsdTestSuite) TestEventIPListSizeAllowlist() {
+	suite.statsd.EventIPListSize(mtglib.NewEventIPListSize(10, false))
+
+	time.Sleep(statsdSleepTime)
+	suite.Contains(suite.statsdServer.String(), "mtg.iplist_size:10|g")
+	suite.Contains(suite.statsdServer.String(), "allowlist")
+}
+
+func (suite *StatsdTestSuite) TestEventIPListSizeBlocklist() {
+	suite.statsd.EventIPListSize(mtglib.NewEventIPListSize(10, true))
+
+	time.Sleep(statsdSleepTime)
+	suite.Contains(suite.statsdServer.String(), "mtg.iplist_size:10|g")
+	suite.Contains(suite.statsdServer.String(), "blocklist")
+}
+
 func TestStatsd(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &StatsdTestSuite{})


### PR DESCRIPTION
As https://github.com/9seconds/mtg/issues/238 showed, sometimes it is valuable to check a size of the iplist within mtg. This PR presents a new metric, `iplist_size`