### PR TITLE
More detail and secure service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,12 +317,15 @@ Now you can create a systemd unit:
 ```console
 $ cat /etc/systemd/system/mtg.service
 [Unit]
-Description=mtg
+Description=mtg - MTProto proxy server
+Documentation=https://github.com/9seconds/mtg
+After=network.target
 
 [Service]
 ExecStart=/usr/local/bin/mtg run /etc/mtg.toml
 Restart=always
 RestartSec=3
+DynamicUser=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
service example in readme is cool, but not enough.

`Description=mtg - MTProto proxy server` - more clean description
`Documentation=https://github.com/9seconds/mtg` - show link on `systemctl status mtg.service`
`After=network.target` - without network mtg is useless
`DynamicUser=true` - main PR reason. [info](https://0pointer.net/blog/dynamic-users-with-systemd.html), [docs](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=). By default mtg in this example will start with `root` rights. It is unacceptable

_BTW, спасибо, Серёжа, за рабочий инструмент. Гораздо лучше официального :з_