### PR TITLE
Does relay buffer not used?

### DIFF
--- a/mtglib/internal/relay/init.go
+++ b/mtglib/internal/relay/init.go
@@ -1,9 +1,5 @@
 package relay
 
-const (
-	copyBufferSize = 64 * 1024
-)
-
 type Logger interface {
 	Printf(msg string, args ...interface{})
 }

--- a/mtglib/internal/relay/pools.go
+++ b/mtglib/internal/relay/pools.go
@@ -1,6 +1,13 @@
+//go:build !linux
+// +build !linux
+
 package relay
 
 import "sync"
+
+const (
+	copyBufferSize = 64 * 1024
+)
 
 var copyBufferPool = sync.Pool{
 	New: func() interface{} {

--- a/mtglib/internal/relay/relay.go
+++ b/mtglib/internal/relay/relay.go
@@ -38,10 +38,7 @@ func pump(log Logger, src, dst essentials.Conn, direction string) {
 	defer src.CloseRead()  //nolint: errcheck
 	defer dst.CloseWrite() //nolint: errcheck
 
-	copyBuffer := acquireCopyBuffer()
-	defer releaseCopyBuffer(copyBuffer)
-
-	n, err := io.CopyBuffer(src, dst, *copyBuffer)
+	n, err := ioCopy(src, dst)
 
 	switch {
 	case err == nil:

--- a/mtglib/internal/relay/relay_linux.go
+++ b/mtglib/internal/relay/relay_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+// +build linux
+
+package relay
+
+import "io"
+
+func ioCopy(dst io.Writer, src io.Reader) (int64, error) {
+	return io.Copy(dst, src)
+}

--- a/mtglib/internal/relay/relay_linux.go
+++ b/mtglib/internal/relay/relay_linux.go
@@ -6,5 +6,5 @@ package relay
 import "io"
 
 func ioCopy(dst io.Writer, src io.Reader) (int64, error) {
-	return io.Copy(dst, src)
+	return io.Copy(dst, src) //nolint: wrapcheck
 }

--- a/mtglib/internal/relay/relay_other.go
+++ b/mtglib/internal/relay/relay_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+// +build !linux
+
+package relay
+
+import "io"
+
+type writerOnly struct {
+	io.Writer
+}
+
+func ioCopy(dst io.Writer, src io.Reader) (int64, error) {
+	copyBuffer := acquireCopyBuffer()
+	defer releaseCopyBuffer(copyBuffer)
+
+	return io.CopyBuffer(writerOnly{dst}, src, *copyBuffer)
+}

--- a/mtglib/internal/relay/relay_other.go
+++ b/mtglib/internal/relay/relay_other.go
@@ -13,5 +13,5 @@ func ioCopy(dst io.Writer, src io.Reader) (int64, error) {
 	copyBuffer := acquireCopyBuffer()
 	defer releaseCopyBuffer(copyBuffer)
 
-	return io.CopyBuffer(writerOnly{dst}, src, *copyBuffer)
+	return io.CopyBuffer(writerOnly{dst}, src, *copyBuffer) //nolint: wrapcheck
 }


### PR DESCRIPTION
Both dst and src should be `*net.TCPConn` in relay process.  
`*net.TCPConn`, which implemented `io.ReaderFrom` interface, will ignore the given buffer and allocate another buffer to perform copy.  
### Why?
https://github.com/golang/go/blob/master/src/io/io.go#L412  
Do `ReadFrom` here.  
https://github.com/golang/go/blob/master/src/net/tcpsock.go#L126  
`*net.TCPConn` ReadFrom, with its private implementation:  
https://github.com/golang/go/blob/51a23d6681aef3736e09fbc61fc9ae03305efc2c/src/net/tcpsock_posix.go#L47  
In `readFrom`, it will tries `splice` and `sendfile` first. `splice` is only supported on Linux. `sendfile` always fails in this case because it requires src to be a file.  
So `io.CopyBuffer` finally come to `genericReadFrom`.  
https://github.com/golang/go/blob/af88fb6502ceee973aaa118471c9d953a10a68e5/src/net/net.go#L673  
There it is. So then it comes back to `io.Copy`, and allocates a default 32 KiB buffer and perform copy. What a joke!  
  
### Why `relay_linux.go` in this PR?
As I said, Linux supports `splice`. When both dst and src are TCP or Unix conn, `splice` will works and make a pipe to relay data. This means the whole copy is a Zero-Copy progress and have a huge improvement on performence. I think it is always the best thing to choose.

For this reason, I made this patch. All these things have not been tested and maybe even what I said is not real. Could you please have a reviewing on it and make a reply? Thanks a lot!  