### PR TITLE
Add support for domain fronting proxy protocol

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -67,6 +67,10 @@ domain-fronting-port = 443
 # default value is not set (DNS resolution is used).
 # domain-fronting-ip = "142.250.185.112"
 
+# This makes a communication between both fronting website and mtg to use
+# proxy protocol.
+domain-fronting-proxy-protocol = false
+
 # FakeTLS can compare timestamps to prevent probes. Each message has
 # encrypted timestamp. So, mtg can compare this timestamp and decide if
 # we need to proceed with connection or not.

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -250,10 +250,11 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen
 		IPAllowlist:     allowlist,
 		EventStream:     eventStream,
 
-		Secret:             conf.Secret,
-		DomainFrontingPort: conf.DomainFrontingPort.Get(mtglib.DefaultDomainFrontingPort),
-		DomainFrontingIP:   conf.DomainFrontingIP.String(),
-		PreferIP:           conf.PreferIP.Get(mtglib.DefaultPreferIP),
+		Secret:                      conf.Secret,
+		DomainFrontingPort:          conf.DomainFrontingPort.Get(mtglib.DefaultDomainFrontingPort),
+		DomainFrontingIP:            conf.DomainFrontingIP.String(),
+		DomainFrontingProxyProtocol: conf.DomainFrontingProxyProtocol.Get(false),
+		PreferIP:                    conf.PreferIP.Get(mtglib.DefaultPreferIP),
 
 		AllowFallbackOnUnknownDC: conf.AllowFallbackOnUnknownDC.Get(false),
 		TolerateTimeSkewness:     conf.TolerateTimeSkewness.Value,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,17 +21,18 @@ type ListConfig struct {
 }
 
 type Config struct {
-	Debug                    TypeBool        `json:"debug"`
-	AllowFallbackOnUnknownDC TypeBool        `json:"allowFallbackOnUnknownDc"`
-	Secret                   mtglib.Secret   `json:"secret"`
-	BindTo                   TypeHostPort    `json:"bindTo"`
-	ProxyProtocolListener    TypeBool        `json:"proxyProtocolListener"`
-	PreferIP                 TypePreferIP    `json:"preferIp"`
-	DomainFrontingPort       TypePort        `json:"domainFrontingPort"`
-	DomainFrontingIP         TypeIP          `json:"domainFrontingIp"`
-	TolerateTimeSkewness     TypeDuration    `json:"tolerateTimeSkewness"`
-	Concurrency              TypeConcurrency `json:"concurrency"`
-	Defense                  struct {
+	Debug                       TypeBool        `json:"debug"`
+	AllowFallbackOnUnknownDC    TypeBool        `json:"allowFallbackOnUnknownDc"`
+	Secret                      mtglib.Secret   `json:"secret"`
+	BindTo                      TypeHostPort    `json:"bindTo"`
+	ProxyProtocolListener       TypeBool        `json:"proxyProtocolListener"`
+	PreferIP                    TypePreferIP    `json:"preferIp"`
+	DomainFrontingPort          TypePort        `json:"domainFrontingPort"`
+	DomainFrontingIP            TypeIP          `json:"domainFrontingIp"`
+	DomainFrontingProxyProtocol TypeBool        `json:"domainFrontingProxyProtocol"`
+	TolerateTimeSkewness        TypeDuration    `json:"tolerateTimeSkewness"`
+	Concurrency                 TypeConcurrency `json:"concurrency"`
+	Defense                     struct {
 		AntiReplay struct {
 			Optional
 

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -9,17 +9,18 @@ import (
 )
 
 type tomlConfig struct {
-	Debug                    bool   `toml:"debug" json:"debug,omitempty"`
-	AllowFallbackOnUnknownDC bool   `toml:"allow-fallback-on-unknown-dc" json:"allowFallbackOnUnknownDc,omitempty"`
-	Secret                   string `toml:"secret" json:"secret"`
-	BindTo                   string `toml:"bind-to" json:"bindTo"`
-	ProxyProtocolListener    bool   `toml:"proxy-protocol-listener" json:"proxyProtocolListener"`
-	PreferIP                 string `toml:"prefer-ip" json:"preferIp,omitempty"`
-	DomainFrontingPort       uint   `toml:"domain-fronting-port" json:"domainFrontingPort,omitempty"`
-	DomainFrontingIP         string `toml:"domain-fronting-ip" json:"domainFrontingIp,omitempty"`
-	TolerateTimeSkewness     string `toml:"tolerate-time-skewness" json:"tolerateTimeSkewness,omitempty"`
-	Concurrency              uint   `toml:"concurrency" json:"concurrency,omitempty"`
-	Defense                  struct {
+	Debug                       bool   `toml:"debug" json:"debug,omitempty"`
+	AllowFallbackOnUnknownDC    bool   `toml:"allow-fallback-on-unknown-dc" json:"allowFallbackOnUnknownDc,omitempty"`
+	Secret                      string `toml:"secret" json:"secret"`
+	BindTo                      string `toml:"bind-to" json:"bindTo"`
+	ProxyProtocolListener       bool   `toml:"proxy-protocol-listener" json:"proxyProtocolListener"`
+	PreferIP                    string `toml:"prefer-ip" json:"preferIp,omitempty"`
+	DomainFrontingPort          uint   `toml:"domain-fronting-port" json:"domainFrontingPort,omitempty"`
+	DomainFrontingIP            string `toml:"domain-fronting-ip" json:"domainFrontingIp,omitempty"`
+	DomainFrontingProxyProtocol bool   `toml:"domain-fronting-proxy-protocol" json:"domainFrontingProxyProtocol,omitempty"`
+	TolerateTimeSkewness        string `toml:"tolerate-time-skewness" json:"tolerateTimeSkewness,omitempty"`
+	Concurrency                 uint   `toml:"concurrency" json:"concurrency,omitempty"`
+	Defense                     struct {
 		AntiReplay struct {
 			Enabled   bool    `toml:"enabled" json:"enabled,omitempty"`
 			MaxSize   string  `toml:"max-size" json:"maxSize,omitempty"`

--- a/mtglib/proxy_opts.go
+++ b/mtglib/proxy_opts.go
@@ -102,6 +102,14 @@ type ProxyOpts struct {
 	// This is an optional setting.
 	DomainFrontingIP string
 
+	// DomainFrontingProxyProtocol is used if communication between upstream
+	// endpoint and mtg supports proxy protocol. This is useful in case
+	// if mtg is also placed behind load balancer, and this will make
+	// fronting webserver to know about real IP addresses
+	//
+	// This is an optional setting.
+	DomainFrontingProxyProtocol bool
+
 	// AllowFallbackOnUnknownDC defines how proxy behaves if unknown DC was
 	// requested. If this setting is set to false, then such connection will be
 	// rejected. Otherwise, proxy will chose any DC.


### PR DESCRIPTION
This fixes https://github.com/9seconds/mtg/issues/335

This PR adds an ability to communicate between upstream and mtg using proxy protocol.

Here is how it can be configured:

```toml
# This makes a communication between both fronting website and mtg to use
# proxy protocol.
domain-fronting-proxy-protocol = false
```