### PR TITLE
Make auto updating optional

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -48,6 +48,11 @@ concurrency = 8192
 #     Only ipv4 connectivity is used
 prefer-ip = "prefer-ipv6"
 
+# If this setting is set, then mtg will try to get proxy updates from Telegram
+# Usually this is completely fine to have it disabled, because mtg has a list
+# of some core proxies hardcoded.
+auto-update = false
+
 # FakeTLS uses domain fronting protection. So it needs to know a port to
 # access.
 #

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -255,6 +255,7 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen
 		DomainFrontingIP:            conf.GetDomainFrontingIP(nil),
 		DomainFrontingProxyProtocol: conf.GetDomainFrontingProxyProtocol(false),
 		PreferIP:                    conf.PreferIP.Get(mtglib.DefaultPreferIP),
+		AutoUpdate:                  conf.AutoUpdate.Get(false),
 
 		AllowFallbackOnUnknownDC: conf.AllowFallbackOnUnknownDC.Get(false),
 		TolerateTimeSkewness:     conf.TolerateTimeSkewness.Value,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	BindTo                      TypeHostPort    `json:"bindTo"`
 	ProxyProtocolListener       TypeBool        `json:"proxyProtocolListener"`
 	PreferIP                    TypePreferIP    `json:"preferIp"`
+	AutoUpdate                  TypeBool        `json:"autoUpdate"`
 	DomainFrontingPort          TypePort        `json:"domainFrontingPort"`
 	DomainFrontingIP            TypeIP          `json:"domainFrontingIp"`
 	DomainFrontingProxyProtocol TypeBool        `json:"domainFrontingProxyProtocol"`

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -15,6 +15,7 @@ type tomlConfig struct {
 	BindTo                      string `toml:"bind-to" json:"bindTo"`
 	ProxyProtocolListener       bool   `toml:"proxy-protocol-listener" json:"proxyProtocolListener"`
 	PreferIP                    string `toml:"prefer-ip" json:"preferIp,omitempty"`
+	AutoUpdate                  bool   `toml:"auto-update" json:"autoUpdate,omitempty"`
 	DomainFrontingPort          uint   `toml:"domain-fronting-port" json:"domainFrontingPort,omitempty"`
 	DomainFrontingIP            string `toml:"domain-fronting-ip" json:"domainFrontingIp,omitempty"`
 	DomainFrontingProxyProtocol bool   `toml:"domain-fronting-proxy-protocol" json:"domainFrontingProxyProtocol,omitempty"`

--- a/mtglib/internal/dc/init.go
+++ b/mtglib/internal/dc/init.go
@@ -57,6 +57,9 @@ var defaultDCAddrSet = dcAddrSet{
 		5: {
 			{Network: "tcp4", Address: "149.154.171.5:443"},
 		},
+		203: {
+			{Network: "tcp4", Address: "91.105.192.100:443"},
+		},
 	},
 	v6: map[int][]Addr{
 		1: {
@@ -73,6 +76,9 @@ var defaultDCAddrSet = dcAddrSet{
 		},
 		5: {
 			{Network: "tcp6", Address: "[2001:b28:f23f:f005::a]:443"},
+		},
+		203: {
+			{Network: "tcp6", Address: "[2a0a:f280:0203:000a:5000:0000:0000:0100]:443"},
 		},
 	},
 }

--- a/mtglib/internal/dc/view_test.go
+++ b/mtglib/internal/dc/view_test.go
@@ -41,6 +41,7 @@ func (suite *ViewTestSuite) TestGetV4() {
 		},
 		203: {
 			{Network: "tcp4", Address: "127.0.0.2:443"},
+			{Network: "tcp4", Address: "91.105.192.100:443"},
 		},
 		2: {
 			{Network: "tcp4", Address: "149.154.167.51:443"},
@@ -60,6 +61,7 @@ func (suite *ViewTestSuite) TestGetV6() {
 		111: {},
 		203: {
 			{Network: "tcp6", Address: "xxx"},
+			{Network: "tcp6", Address: "[2a0a:f280:0203:000a:5000:0000:0000:0100]:443"},
 		},
 		1: {
 			{Network: "tcp6", Address: "[2001:b28:f23d:f001::a]:443"},

--- a/mtglib/proxy.go
+++ b/mtglib/proxy.go
@@ -346,8 +346,10 @@ func NewProxy(opts ProxyOpts) (*Proxy, error) {
 		domainFrontingProxyProtocol: opts.DomainFrontingProxyProtocol,
 	}
 
-	proxy.configUpdater.Run(ctx, dc.PublicConfigUpdateURLv4, "tcp4")
-	proxy.configUpdater.Run(ctx, dc.PublicConfigUpdateURLv6, "tcp6")
+	if opts.AutoUpdate {
+		proxy.configUpdater.Run(ctx, dc.PublicConfigUpdateURLv4, "tcp4")
+		proxy.configUpdater.Run(ctx, dc.PublicConfigUpdateURLv6, "tcp6")
+	}
 
 	pool, err := ants.NewPoolWithFunc(opts.getConcurrency(),
 		func(arg any) {

--- a/mtglib/proxy_opts.go
+++ b/mtglib/proxy_opts.go
@@ -85,6 +85,12 @@ type ProxyOpts struct {
 	// This is an optional setting.
 	PreferIP string
 
+	// AutoUpdate defines if it is required to auto update proxy list from
+	// Telegram instead of relying on a hardcoded list.
+	//
+	// This is an optional setting.
+	AutoUpdate bool
+
 	// DomainFrontingPort is a port we use to connect to a fronting domain.
 	//
 	// This is required because secret does not specify a port. It specifies a


### PR DESCRIPTION
This fixes https://github.com/9seconds/mtg/issues/343 and https://github.com/9seconds/mtg/issues/340

Apparently, sometimes DNS requests via DoH is not a remedy because IP itself could be blocked. In that case users could not fetch lists from Telegram and thus DC 203 will be absent again. This PR makes autoupdating optional.

A lesson here is that proxy has to carry over all IPs it requires.

There is a new relevant setting:

```toml
# If this setting is set, then mtg will try to get proxy updates from Telegram
# Usually this is completely fine to have it disabled, because mtg has a list
# of some core proxies hardcoded.
auto-update = false
```

Default is disabled.