### PR TITLE
Use native dialer for scout

### DIFF
--- a/mtglib/internal/doppel/init.go
+++ b/mtglib/internal/doppel/init.go
@@ -2,6 +2,7 @@ package doppel
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -28,11 +29,15 @@ type Network interface {
 	// Dial establishes context-free TCP connections.
 	Dial(network, address string) (essentials.Conn, error)
 
-	// DialContext dials using a context. This is a preferrable way of
+	// DialContext dials using a context. This is a preferable way of
 	// establishing TCP connections.
 	DialContext(ctx context.Context, network, address string) (essentials.Conn, error)
 
 	// MakeHTTPClient build an HTTP client with given dial function. If nothing is
 	// provided, then DialContext of this interface is going to be used.
 	MakeHTTPClient(func(ctx context.Context, network, address string) (essentials.Conn, error)) *http.Client
+
+	// NativeDialer returns a configured instance of native dialer that
+	// skips proxy connections or any other irrelevant settings.
+	NativeDialer() *net.Dialer
 }

--- a/mtglib/internal/doppel/init_test.go
+++ b/mtglib/internal/doppel/init_test.go
@@ -30,6 +30,10 @@ func (s SimpleNetwork) DialContext(ctx context.Context, network, address string)
 	return conn.(*net.TCPConn), nil
 }
 
+func (s SimpleNetwork) NativeDialer() *net.Dialer {
+	return &net.Dialer{}
+}
+
 func (s SimpleNetwork) MakeHTTPClient(dialFunc func(ctx context.Context, network, address string) (essentials.Conn, error)) *http.Client {
 	if dialFunc == nil {
 		dialFunc = s.DialContext

--- a/mtglib/internal/doppel/scout.go
+++ b/mtglib/internal/doppel/scout.go
@@ -79,18 +79,19 @@ func (s Scout) learn(ctx context.Context, url string) ([]time.Duration, error) {
 }
 
 func (s Scout) makeClient() (*http.Client, *ScoutConnCollected) {
+	dialer := s.network.NativeDialer()
 	collected := NewScoutConnCollected()
 	client := s.network.MakeHTTPClient(func(
 		ctx context.Context,
 		network string,
 		address string,
 	) (essentials.Conn, error) {
-		conn, err := s.network.DialContext(ctx, network, address)
+		conn, err := dialer.DialContext(ctx, network, address)
 		if err != nil {
 			return nil, err
 		}
 
-		return NewScoutConn(conn, collected), nil
+		return NewScoutConn(essentials.WrapNetConn(conn), collected), nil
 	})
 
 	return client, collected


### PR DESCRIPTION
It seems there should be the same consideration as for https://github.com/9seconds/mtg/pull/353: scout should ignore proxies to avoid getting longer delays and skewed statistics. Also, this is very logical that those URLs should be accessible by mtg directly.