### PR TITLE
Decrease relay buffer size

### DIFF
--- a/mtglib/internal/relay/init.go
+++ b/mtglib/internal/relay/init.go
@@ -1,9 +1,5 @@
 package relay
 
-const (
-	copyBufferSize = 64 * 1024
-)
-
 type Logger interface {
 	Printf(msg string, args ...any)
 }

--- a/mtglib/internal/relay/relay.go
+++ b/mtglib/internal/relay/relay.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/9seconds/mtg/v2/essentials"
+	"github.com/9seconds/mtg/v2/mtglib/internal/tls"
 )
 
 func Relay(ctx context.Context, log Logger, telegramConn, clientConn essentials.Conn) {
@@ -35,7 +36,7 @@ func Relay(ctx context.Context, log Logger, telegramConn, clientConn essentials.
 }
 
 func pump(log Logger, src, dst essentials.Conn, direction string) {
-	var buf [copyBufferSize]byte
+	var buf [tls.MaxRecordPayloadSize]byte
 
 	defer src.CloseRead()  //nolint: errcheck
 	defer dst.CloseWrite() //nolint: errcheck


### PR DESCRIPTION
Even if it makes sense to have a huge buffers, we do artificial delays now. In that case we could achieve the same results with a lower buffer. If not, then we won't send a packet bigger that this value