### PR TITLE
Add more architectures for mtg

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,6 @@ builds:
     flags:
       - -trimpath
       - -mod=readonly
-      - -pgo=auto
     ldflags: -s -w -X main.version={{ .Version }}
     ignore:
       - goos: darwin
@@ -63,7 +62,6 @@ builds:
     flags:
       - -trimpath
       - -mod=readonly
-      - -pgo=auto
     ldflags: -s -w -X main.version={{ .Version }}
   - id: arm64-v9
     binary: '{{ .ProjectName }}'
@@ -79,7 +77,6 @@ builds:
     flags:
       - -trimpath
       - -mod=readonly
-      - -pgo=auto
     ldflags: -s -w -X main.version={{ .Version }}
   - id: amd64-v3
     binary: '{{ .ProjectName }}'
@@ -99,7 +96,6 @@ builds:
     flags:
       - -trimpath
       - -mod=readonly
-      - -pgo=auto
     ldflags: -s -w -X main.version={{ .Version }}
 
 archives:


### PR DESCRIPTION
Now we are going to have:

1. Windows. Both ARM64 and AMD64 variants
2. MIPS (read - OpenWRT)
3. [ARMv9](https://www.arm.com/architecture/cpu/a-profile/armv9)
4. AMD64v3