### PR TITLE
Document a necessety of increasing limits for systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ ExecStart=/usr/local/bin/mtg run /etc/mtg.toml
 Restart=always
 RestartSec=3
 DynamicUser=true
+LimitNOFILE=65536
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]


### PR DESCRIPTION
It seems that default DynamicUser limits are very low. We have to increase them anyway.

This is related to https://github.com/9seconds/mtg/issues/378