### PR TITLE
Add Config.GetConcurrency with default fallback

### DIFF
--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -253,6 +253,7 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen
 		EventStream:     eventStream,
 
 		Secret:                      conf.Secret,
+		Concurrency:                 conf.GetConcurrency(mtglib.DefaultConcurrency),
 		DomainFrontingPort:          conf.GetDomainFrontingPort(mtglib.DefaultDomainFrontingPort),
 		DomainFrontingIP:            conf.GetDomainFrontingIP(nil),
 		DomainFrontingProxyProtocol: conf.GetDomainFrontingProxyProtocol(false),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,13 @@ type Config struct {
 	} `json:"stats"`
 }
 
+func (c *Config) GetConcurrency(defaultValue uint) uint {
+	if concurrency := c.Concurrency.Get(0); concurrency != 0 {
+		return concurrency
+	}
+	return c.Concurrency.Get(defaultValue)
+}
+
 func (c *Config) GetDNS() *url.URL {
 	var dohURL *url.URL
 


### PR DESCRIPTION
Сейчас значение concurrency из файла конфига при запуске приложения через `mtg run config.toml` полностью игнорируется.
PR добавляет проброс значения из текстового файла в ProxyOpts