### PR TITLE
Allow using directory bind mounts for a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,19 @@ FROM golang:1.26-alpine AS build
 
 ENV CGO_ENABLED=0
 
+# this is done for backward compatibility: before that we mounted a config
+# into /config.toml. Some application allow mounting directories only,
+# so it makes problems. So, instead we are going to do 2 steps:
+#  1. Create /config/config.toml as a symlink to /config.toml
+#  2. Force /mtg to use /config/config.toml
+#
+# it helps in both ways: users with directories could use /config directory
+# and overlap a symlink by their bind mount. Old users could continue using
+# /config.toml as a real config.
+RUN set -x \
+  && mkdir -p /config \
+  && ln -sv /config.toml /config/config.toml
+
 RUN --mount=type=cache,target=/var/cache/apk \
     set -x \
     && apk --update add \
@@ -35,8 +48,9 @@ RUN set -x \
 FROM scratch
 
 ENTRYPOINT ["/mtg"]
-CMD ["run", "/config.toml"]
+CMD ["run", "/config/config.toml"]
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /app/mtg /mtg
 COPY --from=build /app/example.config.toml /config.toml
+COPY --from=build /config /config


### PR DESCRIPTION
This helps with a situation when some applications do not allow mounting individual files, but whole directories. In that case users could mount `/config` directory with a single file, `config.toml`: `-v /path/to/dir:/config`. Also, there is a backward compatibility to using a single `/config.toml`

Fixes https://github.com/9seconds/mtg/issues/396