### PR TITLE
fix: prevent index out of range panic on 32-bit platforms

### DIFF
--- a/events/event_stream.go
+++ b/events/event_stream.go
@@ -38,7 +38,7 @@ func (e EventStream) Send(ctx context.Context, evt mtglib.Event) {
 	select {
 	case <-ctx.Done():
 	case <-e.ctx.Done():
-	case e.chans[int(chanNo)%len(e.chans)] <- evt:
+	case e.chans[chanNo%uint32(len(e.chans))] <- evt:
 	}
 }
 


### PR DESCRIPTION
On 32-bit architectures (e.g. ARM7), `int` is 32 bits wide. Casting a `uint32` hash value to `int` can overflow, producing a negative number. Go's modulo operator preserves the sign, so the channel index can become `-1`, causing a panic:

```
index out of range [-1]
```

This happens roughly 50% of the time — whenever the xxhash result exceeds `math.MaxInt32`.

The fix performs the modulo in `uint32` space before indexing the slice, ensuring the result is always non-negative.

Fixes #413