### PR TITLE
Decrease a relay buffer size for MIPS devices

### DIFF
--- a/mtglib/internal/relay/pool_settings_mips.go
+++ b/mtglib/internal/relay/pool_settings_mips.go
@@ -1,0 +1,13 @@
+//go:build mips || mipsle
+
+package relay
+
+import "github.com/9seconds/mtg/v2/mtglib/internal/tls"
+
+const (
+	// MIPS is quite short in resources, and usually it means that it will run
+	// on Microtiks, OpenWRT-based routers or similar hardware. I think it worth
+	// to sacrifice a number of read syscalls (read, CPU load) to shrink
+	// limited RAM resources.
+	bufPoolSize = tls.MaxRecordPayloadSize / 2
+)

--- a/mtglib/internal/relay/pool_settings_other.go
+++ b/mtglib/internal/relay/pool_settings_other.go
@@ -1,0 +1,9 @@
+//go:build !mips && !mipsle
+
+package relay
+
+import "github.com/9seconds/mtg/v2/mtglib/internal/tls"
+
+const (
+	bufPoolSize = tls.MaxRecordPayloadSize
+)

--- a/mtglib/internal/relay/pools.go
+++ b/mtglib/internal/relay/pools.go
@@ -1,0 +1,18 @@
+package relay
+
+import "sync"
+
+var bufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, bufPoolSize)
+		return &b
+	},
+}
+
+func acquireBuffer() *[]byte {
+	return bufPool.Get().(*[]byte)
+}
+
+func releaseBuffer(p *[]byte) {
+	bufPool.Put(p)
+}

--- a/mtglib/internal/relay/relay.go
+++ b/mtglib/internal/relay/relay.go
@@ -4,18 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
-	"sync"
 
 	"github.com/9seconds/mtg/v2/essentials"
-	"github.com/9seconds/mtg/v2/mtglib/internal/tls"
 )
-
-var bufPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, tls.MaxRecordPayloadSize)
-		return &b
-	},
-}
 
 func Relay(ctx context.Context, log Logger, telegramConn, clientConn essentials.Conn) {
 	defer telegramConn.Close() //nolint: errcheck
@@ -44,13 +35,13 @@ func Relay(ctx context.Context, log Logger, telegramConn, clientConn essentials.
 }
 
 func pump(log Logger, src, dst essentials.Conn, direction string) {
-	bp := bufPool.Get().(*[]byte)
-	defer bufPool.Put(bp)
+	buf := acquireBuffer()
+	defer releaseBuffer(buf)
 
 	defer src.CloseRead()  //nolint: errcheck
 	defer dst.CloseWrite() //nolint: errcheck
 
-	n, err := io.CopyBuffer(src, dst, *bp)
+	n, err := io.CopyBuffer(src, dst, *buf)
 
 	switch {
 	case err == nil:


### PR DESCRIPTION
This is a logical continuation of @dolonet work on [reducing memory overhead](https://github.com/9seconds/mtg/pull/414) per connection. Since we have started to [support MIPS hardware](https://github.com/9seconds/mtg/pull/386), it makes sense to have some optimizations in this regard.

Usually those devices are consumer hardware that runs either RouterOS or different flavors of OpenWRT. These devices are very limited in resources, so none gonna run large scale there. In this case it makes sense to decrease memory usage there by trading CPU cycles.

I haven't measured an impact because do not have such device available at this moment but here is how Opus measured a connection requirements:

| Component | Size |
 |---|---|
 | **Relay buffers (2×16KB)** | **~33 KB** |
 | Goroutine stacks (2×) | ~33 KB |
 | Doppel write buffer | ~16 KB |
 | TLS state (bufio + readBuf) | ~8 KB |
 | Doppel conn state | ~4 KB |
 | Other (cipher, ctx, wrappers) | ~1 KB |
 | **Total** | **~95 KB** |

So, if we cut relay buffer sizes from 16 to 8, this gonna make ~17% difference.