### PR TITLE
Change IP address set priority

### DIFF
--- a/mtglib/internal/dc/view.go
+++ b/mtglib/internal/dc/view.go
@@ -5,15 +5,19 @@ type dcView struct {
 }
 
 func (d dcView) getV4(dc int) []Addr {
-	addrs := d.publicConfigs.getV4(dc)
+	var addrs []Addr
+
 	addrs = append(addrs, defaultDCAddrSet.getV4(dc)...)
+	addrs = append(addrs, d.publicConfigs.getV4(dc)...)
 
 	return addrs
 }
 
 func (d dcView) getV6(dc int) []Addr {
-	addrs := d.publicConfigs.getV6(dc)
+	var addrs []Addr
+
 	addrs = append(addrs, defaultDCAddrSet.getV6(dc)...)
+	addrs = append(addrs, d.publicConfigs.getV6(dc)...)
 
 	return addrs
 }


### PR DESCRIPTION
For a couple of releases we use collected IPs as a prioritized source for connecting to Telegram. But apparently, they work way worse than it should, and having connectivity to core ip ALWAYS gives better results. Thus, this PR flips priorities, so users could have auto-update enabled as a source of secondary addresses, not primary ones