### PR TITLE
Fix TCP keepalive setup on OpenBSD

### DIFF
--- a/network/sockopts.go
+++ b/network/sockopts.go
@@ -20,7 +20,7 @@ func SetServerSocketOptions(conn net.Conn, bufferSize int) error {
 }
 
 func setCommonSocketOptions(conn *net.TCPConn) error {
-	if err := conn.SetKeepAliveConfig(net.KeepAliveConfig{
+	if err := applyKeepAlive(conn, net.KeepAliveConfig{
 		Enable:   true,
 		Idle:     DefaultKeepAliveIdle,
 		Interval: DefaultKeepAliveInterval,

--- a/network/sockopts_keepalive.go
+++ b/network/sockopts_keepalive.go
@@ -1,0 +1,11 @@
+//go:build !openbsd
+
+package network
+
+import "net"
+
+// applyKeepAlive enables TCP keepalive on conn and applies the per-socket
+// idle/interval/count tuning from cfg.
+func applyKeepAlive(conn *net.TCPConn, cfg net.KeepAliveConfig) error {
+	return conn.SetKeepAliveConfig(cfg) //nolint: wrapcheck
+}

--- a/network/sockopts_keepalive_openbsd.go
+++ b/network/sockopts_keepalive_openbsd.go
@@ -1,0 +1,20 @@
+package network
+
+import "net"
+
+// applyKeepAlive enables (or disables) TCP keepalive on conn.
+//
+// OpenBSD has no user-settable per-socket TCP keepalive options: TCP_KEEPIDLE,
+// TCP_KEEPINTVL and TCP_KEEPCNT do not exist on OpenBSD, and Go's
+// (*TCPConn).SetKeepAliveConfig therefore returns ENOPROTOOPT ("protocol not
+// available") for any non-negative Idle/Interval/Count value (see
+// src/net/tcpsockopt_openbsd.go in the Go source tree). Calling
+// SetKeepAliveConfig with mtg's defaults (zero values) breaks every accepted
+// listener connection and every outbound dial on OpenBSD.
+//
+// On OpenBSD we only flip SO_KEEPALIVE on or off; the keepalive timing is
+// controlled system-wide via the sysctl knobs net.inet.tcp.keepidle and
+// net.inet.tcp.keepintvl.
+func applyKeepAlive(conn *net.TCPConn, cfg net.KeepAliveConfig) error {
+	return conn.SetKeepAlive(cfg.Enable) //nolint: wrapcheck
+}

--- a/network/v2/sockopts.go
+++ b/network/v2/sockopts.go
@@ -6,7 +6,7 @@ import (
 )
 
 func setCommonSocketOptions(conn *net.TCPConn, keepAliveConfig net.KeepAliveConfig) error {
-	if err := conn.SetKeepAliveConfig(keepAliveConfig); err != nil {
+	if err := applyKeepAlive(conn, keepAliveConfig); err != nil {
 		return fmt.Errorf("cannot configure TCP keepalive: %w", err)
 	}
 

--- a/network/v2/sockopts_keepalive.go
+++ b/network/v2/sockopts_keepalive.go
@@ -1,0 +1,11 @@
+//go:build !openbsd
+
+package network
+
+import "net"
+
+// applyKeepAlive enables TCP keepalive on conn and applies the per-socket
+// idle/interval/count tuning from cfg.
+func applyKeepAlive(conn *net.TCPConn, cfg net.KeepAliveConfig) error {
+	return conn.SetKeepAliveConfig(cfg) //nolint: wrapcheck
+}

--- a/network/v2/sockopts_keepalive_openbsd.go
+++ b/network/v2/sockopts_keepalive_openbsd.go
@@ -1,0 +1,20 @@
+package network
+
+import "net"
+
+// applyKeepAlive enables (or disables) TCP keepalive on conn.
+//
+// OpenBSD has no user-settable per-socket TCP keepalive options: TCP_KEEPIDLE,
+// TCP_KEEPINTVL and TCP_KEEPCNT do not exist on OpenBSD, and Go's
+// (*TCPConn).SetKeepAliveConfig therefore returns ENOPROTOOPT ("protocol not
+// available") for any non-negative Idle/Interval/Count value (see
+// src/net/tcpsockopt_openbsd.go in the Go source tree). Calling
+// SetKeepAliveConfig with mtg's defaults (zero values) breaks every accepted
+// listener connection and every outbound dial on OpenBSD.
+//
+// On OpenBSD we only flip SO_KEEPALIVE on or off; the keepalive timing is
+// controlled system-wide via the sysctl knobs net.inet.tcp.keepidle and
+// net.inet.tcp.keepintvl.
+func applyKeepAlive(conn *net.TCPConn, cfg net.KeepAliveConfig) error {
+	return conn.SetKeepAlive(cfg.Enable) //nolint: wrapcheck
+}


### PR DESCRIPTION
Fixes #457.

## Problem

OpenBSD has no user-settable per-socket TCP keepalive options. `TCP_KEEPIDLE`, `TCP_KEEPINTVL` and `TCP_KEEPCNT` do not exist on OpenBSD; keepalive timing is controlled system-wide via the sysctls `net.inet.tcp.keepidle` and `net.inet.tcp.keepintvl`. The Go runtime reflects this in [`src/net/tcpsockopt_openbsd.go`](https://github.com/golang/go/blob/master/src/net/tcpsockopt_openbsd.go): `setKeepAliveIdle` / `setKeepAliveInterval` / `setKeepAliveCount` return `ENOPROTOOPT` for any non-negative value, and only short-circuit to `nil` for negative values (the explicit "leave alone" sentinel).

mtg builds a `net.KeepAliveConfig` with zero-valued `Idle` / `Interval` / `Count` whenever the user does not override them, which is the default and the documented expectation. It then hands that config to `(*TCPConn).SetKeepAliveConfig` in two places:

- `network/sockopts.go` — applied to every connection accepted by `internal/utils.Listener.Accept` and to every server-side dial that goes through the v1 default network.
- `network/v2/sockopts.go` — applied to every connection produced by the v2 network's `DialContext`.

Both calls fail on OpenBSD with `set tcp ...: protocol not available`. The user-visible effects:

- `mtg doctor` reports the error for every Telegram DC.
- `mtg run` accepts incoming TCP connections at the kernel level but `Listener.Accept` closes each one before the proxy server ever sees it, so the client appears to hang on a half-open socket and nothing is written to the log. This is exactly what @babut85 reports in #457.
- There is no configuration workaround. Setting `[network] keep-alive.disabled = true` only zeroes `Enable`; Go's `SetKeepAliveConfig` still calls all four setters, and three of them still fail.

## Fix

Extract the keepalive setup behind an `applyKeepAlive(conn, cfg)` helper that has a per-platform implementation, following the same build-tag pattern already used for `sockopts_lowat`, `sockopts_congestion`, `sockopts_reuseaddr` and `sockopts_usertimeout`.

- **All platforms except OpenBSD** (`//go:build !openbsd`): `applyKeepAlive` calls `conn.SetKeepAliveConfig(cfg)`. Behaviour is unchanged.
- **OpenBSD** (`//go:build openbsd`): `applyKeepAlive` calls `conn.SetKeepAlive(cfg.Enable)`, which only flips `SO_KEEPALIVE` on or off and never touches the missing per-socket options. OpenBSD users get the system-wide sysctl-controlled keepalive timing, which is the only thing the kernel exposes.

The same fix is applied symmetrically in `network/` (v1) and `network/v2/`.

## Verified

- `GOOS=openbsd GOARCH=amd64 go build ./...` — clean.
- `GOOS=openbsd GOARCH=arm64 go build ./...` — clean.
- `go vet ./...` clean for both `linux` and `openbsd`.
- `go test -count=1 ./network/...` passes on linux.

Cannot run the test suite under OpenBSD locally; happy to iterate if anything turns up on a real OpenBSD host.