### PR TITLE
Warn about SNI/IP mismatch at proxy startup

### DIFF
--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/9seconds/mtg/v2/antireplay"
 	"github.com/9seconds/mtg/v2/events"
@@ -207,7 +208,67 @@ func makeEventStream(conf *config.Config, logger mtglib.Logger) (mtglib.EventStr
 	return events.NewNoopStream(), nil
 }
 
-func runProxy(conf *config.Config, version string) error { //nolint: funlen
+func warnSNIMismatch(conf *config.Config, ntw mtglib.Network, log mtglib.Logger) {
+	host := conf.Secret.Host
+	if host == "" {
+		return
+	}
+
+	addresses, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		log.BindStr("hostname", host).
+			WarningError("SNI-DNS check: cannot resolve secret hostname", err)
+		return
+	}
+
+	ourIP4 := conf.PublicIPv4.Get(nil)
+	if ourIP4 == nil {
+		ourIP4 = getIP(ntw, "tcp4")
+	}
+
+	ourIP6 := conf.PublicIPv6.Get(nil)
+	if ourIP6 == nil {
+		ourIP6 = getIP(ntw, "tcp6")
+	}
+
+	if ourIP4 == nil && ourIP6 == nil {
+		log.Warning("SNI-DNS check: cannot detect public IP address; set public-ipv4/public-ipv6 in config or run 'mtg doctor'")
+		return
+	}
+
+	for _, addr := range addresses {
+		if (ourIP4 != nil && addr.IP.String() == ourIP4.String()) ||
+			(ourIP6 != nil && addr.IP.String() == ourIP6.String()) {
+			return
+		}
+	}
+
+	resolved := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		resolved = append(resolved, addr.IP.String())
+	}
+
+	our := ""
+	if ourIP4 != nil {
+		our = ourIP4.String()
+	}
+
+	if ourIP6 != nil {
+		if our != "" {
+			our += "/"
+		}
+
+		our += ourIP6.String()
+	}
+
+	log.BindStr("hostname", host).
+		BindStr("resolved", strings.Join(resolved, ", ")).
+		BindStr("public_ip", our).
+		Warning("SNI-DNS mismatch: secret hostname does not resolve to this server's public IP. " +
+			"DPI may detect and block the proxy. See 'mtg doctor' for details")
+}
+
+func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyclop
 	logger := makeLogger(conf)
 
 	logger.BindJSON("configuration", conf.String()).Debug("configuration")
@@ -221,6 +282,8 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen
 	if err != nil {
 		return fmt.Errorf("cannot build network: %w", err)
 	}
+
+	warnSNIMismatch(conf, ntw, logger)
 
 	blocklist, err := makeIPBlocklist(
 		conf.Defense.Blocklist,

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -236,11 +236,21 @@ func warnSNIMismatch(conf *config.Config, ntw mtglib.Network, log mtglib.Logger)
 		return
 	}
 
+	v4Match := ourIP4 == nil
+	v6Match := ourIP6 == nil
+
 	for _, addr := range addresses {
-		if (ourIP4 != nil && addr.IP.String() == ourIP4.String()) ||
-			(ourIP6 != nil && addr.IP.String() == ourIP6.String()) {
-			return
+		if ourIP4 != nil && addr.IP.String() == ourIP4.String() {
+			v4Match = true
 		}
+
+		if ourIP6 != nil && addr.IP.String() == ourIP6.String() {
+			v6Match = true
+		}
+	}
+
+	if v4Match && v6Match {
+		return
 	}
 
 	resolved := make([]string, 0, len(addresses))
@@ -261,11 +271,20 @@ func warnSNIMismatch(conf *config.Config, ntw mtglib.Network, log mtglib.Logger)
 		our += ourIP6.String()
 	}
 
-	log.BindStr("hostname", host).
+	entry := log.BindStr("hostname", host).
 		BindStr("resolved", strings.Join(resolved, ", ")).
-		BindStr("public_ip", our).
-		Warning("SNI-DNS mismatch: secret hostname does not resolve to this server's public IP. " +
-			"DPI may detect and block the proxy. See 'mtg doctor' for details")
+		BindStr("public_ip", our)
+
+	if ourIP4 != nil {
+		entry = entry.BindStr("ipv4_match", fmt.Sprintf("%t", v4Match))
+	}
+
+	if ourIP6 != nil {
+		entry = entry.BindStr("ipv6_match", fmt.Sprintf("%t", v6Match))
+	}
+
+	entry.Warning("SNI-DNS mismatch: secret hostname does not resolve to this server's public IP. " +
+		"DPI may detect and block the proxy. See 'mtg doctor' for details")
 }
 
 func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyclop


### PR DESCRIPTION
## Summary

The SNI-DNS validation that `mtg doctor` already performs is now also
run once at `mtg run` startup. If the secret hostname does not resolve
to the server's public IP, a warning is logged so that operators notice
the misconfiguration before DPI silently blocks the proxy.

The check is best-effort and never prevents the proxy from starting:
- If the public IP cannot be detected, a short warning is emitted.
- If DNS resolution fails, a warning with the error is emitted.
- On a match, nothing is logged (no noise in normal operation).

## Motivation

Most operators only discover the SNI/IP mismatch after their proxy has
already been blocked. `mtg doctor` catches this, but many people skip
it — especially in docker/systemd setups where you deploy and forget.
A startup warning surfaces the problem at exactly the right moment.

Discussed in #458 (comment by @9seconds: "Наверное да, хорошая идея").

## Changes

- `internal/cli/run_proxy.go`: new `warnSNIMismatch()` function, called
  after the network is initialised. Reuses `getIP()` from `utils.go`
  (same logic as `doctor.go:checkSecretHost`).

## Test plan

- `go build ./...` — clean
- `go vet ./internal/cli/...` — clean
- Manually verified: with a mismatched hostname the warning appears in
  the log; with a matching hostname no warning is emitted.

Refs: #444, #458