### PR TITLE
docs: warn about firehol_level1 RFC1918 gotcha in default blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,8 +529,9 @@ message like:
 The reason is that the default blocklist (`firehol_level1.netset`)
 includes bogon networks, which covers all RFC1918 ranges
 (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`). Any client
-connecting from such an address is rejected by the blocklist and
-silently routed to the fronting domain.
+connecting from such an address is rejected by the blocklist —
+the TCP connection is closed immediately with no response, so
+from the client's point of view nothing loads at all.
 
 There are three ways to resolve it:
 

--- a/README.md
+++ b/README.md
@@ -514,6 +514,49 @@ This is not very necessary. Keep in mind these rules:
    you can enable `drs` setting.
 9. **If you are not sure, touch nothing!**
 
+## Troubleshooting
+
+### `ip was blacklisted` for clients on the same LAN
+
+If you run mtg at home and a client on the same LAN (for example, your
+phone on the home Wi-Fi) cannot connect, check the proxy logs for a
+message like:
+
+```json
+{"level":"info","ip":"10.0.1.1","logger":"proxy","message":"ip was blacklisted"}
+```
+
+The reason is that the default blocklist (`firehol_level1.netset`)
+includes bogon networks, which covers all RFC1918 ranges
+(`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`). Any client
+connecting from such an address is rejected by the blocklist and
+silently routed to the fronting domain.
+
+There are three ways to resolve it:
+
+1. Disable the blocklist entirely in `config.toml`:
+
+   ```toml
+   [defense.blocklist]
+   enabled = false
+   ```
+
+   Simplest option if the proxy is used only by you and people you trust.
+
+2. Keep the blocklist but swap `firehol_level1` for a narrower list that
+   does not include bogons, for example `firehol_abusers_1d`:
+
+   ```toml
+   [defense.blocklist]
+   enabled = true
+   urls = ["https://iplists.firehol.org/files/firehol_abusers_1d.netset"]
+   ```
+
+3. Connect to the proxy through a public IP or domain name with hairpin
+   NAT (`MASQUERADE`) on your router. mtg will then see the client with
+   its public address and the blocklist will not match. This is more
+   work to set up but preserves full blocklist protection.
+
 ## Metrics
 
 Out of the box, mtg works with

--- a/example.config.toml
+++ b/example.config.toml
@@ -321,8 +321,8 @@ download-concurrency = 2
 # networks, and therefore RFC1918 ranges as well (10.0.0.0/8,
 # 172.16.0.0/12, 192.168.0.0/16). If you run mtg on a home/LAN network
 # and connect from a client on the same LAN, that client will be
-# rejected with "ip was blacklisted" and silently routed to the fronting
-# domain. If you see this, you can either disable this section
+# rejected with "ip was blacklisted" and the connection dropped (TCP
+# close, no response). If you see this, you can either disable this section
 # (enabled = false), replace firehol_level1 with a narrower list that
 # does not include bogons (e.g. firehol_abusers_1d), or connect via
 # a public IP/domain with hairpin NAT on your router. See README for

--- a/example.config.toml
+++ b/example.config.toml
@@ -316,6 +316,17 @@ download-concurrency = 2
 # A list of URLs in FireHOL format (https://iplists.firehol.org/)
 # You can provider links here (starts with https:// or http://) or
 # path to a local file, but in this case it should be absolute.
+#
+# NOTE: the default list below (firehol_level1.netset) includes bogon
+# networks, and therefore RFC1918 ranges as well (10.0.0.0/8,
+# 172.16.0.0/12, 192.168.0.0/16). If you run mtg on a home/LAN network
+# and connect from a client on the same LAN, that client will be
+# rejected with "ip was blacklisted" and silently routed to the fronting
+# domain. If you see this, you can either disable this section
+# (enabled = false), replace firehol_level1 with a narrower list that
+# does not include bogons (e.g. firehol_abusers_1d), or connect via
+# a public IP/domain with hairpin NAT on your router. See README for
+# details.
 urls = [
     "https://iplists.firehol.org/files/firehol_level1.netset",
     # "/local.file"


### PR DESCRIPTION
## Summary

Follow-up to #466. The default `[defense.blocklist]` uses `firehol_level1.netset`, which includes bogon networks and therefore all RFC1918 ranges. Clients connecting from the same LAN as mtg (typical home setup: phone on Wi-Fi, mtg on a home server) are silently rejected with `ip was blacklisted` and routed to the fronting domain. This keeps tripping people up.

This PR is docs-only and does not change the default behavior:

- `example.config.toml`: a short `NOTE` block next to `[defense.blocklist].urls` describing the gotcha and pointing to the README.
- `README.md`: a new `## Troubleshooting` section before `## Metrics` with the symptom (including the exact log line), the cause, and three resolution paths (disable the blocklist, swap for a narrower list like `firehol_abusers_1d`, or use hairpin NAT).

No defaults are changed — that is a separate discussion and I didn't want to couple it with a doc fix. Happy to open a follow-up issue/PR if you'd like to revisit the default list choice.

Refs #466.

## Test plan

- [x] `example.config.toml` still parses as TOML (only comment lines added).
- [x] README renders correctly on GitHub (verified locally against existing code blocks).
- [x] No behavior/code changes — docs only.