### PR TITLE
Include YunoHost installation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ where _443_ is a host port (a port you want to connect to from a
 client), and _3128_ is the one you have in your config in the `bind-to`
 section.
 
+Additionally, for simple installation on [YunoHost](https://yunohost.org) you can use: https://github.com/YunoHost-Apps/mtg_ynh
+
 ### Access a proxy
 
 Now you can generate some useful links:


### PR DESCRIPTION
I've added package https://github.com/YunoHost-Apps/mtg_ynh  for easier installation on YunoHost self managed server, as i believe that need to spread such tools in most easy way to be used. 
and as it was approved by yunohost community, raising this small pr to update readme.

and it is already running in 3 servers, more to go. 

Thanks for your solution!