### PR TITLE
config: accept hostname for [domain-fronting] target

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -118,13 +118,16 @@ allow-fallback-on-unknown-dc = false
 #
 # Use `host` — accepts a hostname or a literal IP. Hostnames are resolved
 # at dial time, so a dual-stack DNS record can reach the right backend
-# address family for IPv4 or IPv6 clients. `ip` is kept for backward
-# compatibility (literal IP only). Setting both is an error.
+# address family for IPv4 or IPv6 clients.
 #
 # The hostname from the secret is still used for SNI in the TLS handshake.
 #
 # default value is not set (the secret's hostname is used).
 # host = "fronting-backend"
+
+# Deprecated: use `host`. If `ip` is set, mtg logs a warning at startup
+# and ignores the value (domain-fronting falls back to the secret's
+# hostname unless `host` is also set).
 # ip = "10.10.10.11"
 
 # FakeTLS uses domain fronting protection. So it needs to know a port to

--- a/example.config.toml
+++ b/example.config.toml
@@ -112,11 +112,19 @@ allow-fallback-on-unknown-dc = false
 # required.
 [domain-fronting]
 # By default, mtg resolves the fronting hostname (from the secret) via DNS
-# to establish a TCP connection. If DNS resolution of that hostname is blocked,
-# you can specify an IP address to connect to directly. The hostname is still
-# used for SNI in the TLS handshake.
+# to establish a TCP connection. If that resolution is blocked, or loops
+# back to this server (e.g. mtg sits behind an SNI router whose DNS points
+# at itself), override the destination here.
 #
-# default value is not set (DNS resolution is used).
+# Use `host` for a hostname (resolved at dial time, so a dual-stack DNS
+# record can reach the right backend address family for IPv4 or IPv6
+# clients) or for a literal IP. Use `ip` if you specifically need a
+# literal IP and want strict IP validation. Setting both is an error.
+#
+# The hostname from the secret is still used for SNI in the TLS handshake.
+#
+# default value is not set (the secret's hostname is used).
+# host = "fronting-backend"
 # ip = "10.10.10.11"
 
 # FakeTLS uses domain fronting protection. So it needs to know a port to

--- a/example.config.toml
+++ b/example.config.toml
@@ -116,10 +116,10 @@ allow-fallback-on-unknown-dc = false
 # back to this server (e.g. mtg sits behind an SNI router whose DNS points
 # at itself), override the destination here.
 #
-# Use `host` for a hostname (resolved at dial time, so a dual-stack DNS
-# record can reach the right backend address family for IPv4 or IPv6
-# clients) or for a literal IP. Use `ip` if you specifically need a
-# literal IP and want strict IP validation. Setting both is an error.
+# Use `host` — accepts a hostname or a literal IP. Hostnames are resolved
+# at dial time, so a dual-stack DNS record can reach the right backend
+# address family for IPv4 or IPv6 clients. `ip` is kept for backward
+# compatibility (literal IP only). Setting both is an error.
 #
 # The hostname from the secret is still used for SNI in the TLS handshake.
 #

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -140,7 +140,18 @@ func (d *Doctor) checkDeprecatedConfig() bool {
 			"when":        "2.3.0",
 			"old":         "domain-fronting-ip",
 			"old_section": "",
-			"new":         "ip",
+			"new":         "host",
+			"new_section": "domain-fronting",
+		})
+	}
+
+	if d.conf.DomainFronting.IP.Value != nil {
+		ok = false
+		tplWDeprecatedConfig.Execute(os.Stdout, map[string]string{ //nolint: errcheck
+			"when":        "2.4.0",
+			"old":         "ip",
+			"old_section": "domain-fronting",
+			"new":         "host",
 			"new_section": "domain-fronting",
 		})
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -298,8 +298,8 @@ func (d *Doctor) checkNetworkAddresses(ntw mtglib.Network, addresses []string) e
 
 func (d *Doctor) checkFrontingDomain(ntw mtglib.Network) bool {
 	host := d.conf.Secret.Host
-	if ip := d.conf.GetDomainFrontingIP(nil); ip != "" {
-		host = ip
+	if override := d.conf.GetDomainFrontingHost(); override != "" {
+		host = override
 	}
 
 	port := d.conf.GetDomainFrontingPort(mtglib.DefaultDomainFrontingPort)

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -287,10 +287,22 @@ func warnSNIMismatch(conf *config.Config, ntw mtglib.Network, log mtglib.Logger)
 		"DPI may detect and block the proxy. See 'mtg doctor' for details")
 }
 
+func warnDeprecatedDomainFronting(conf *config.Config, log mtglib.Logger) {
+	if conf.DomainFrontingIP.Value != nil {
+		log.Warning(`config option "domain-fronting-ip" is deprecated and ignored; use "host" in [domain-fronting] instead`)
+	}
+
+	if conf.DomainFronting.IP.Value != nil {
+		log.Warning(`config option "ip" in [domain-fronting] is deprecated and ignored; use "host" instead`)
+	}
+}
+
 func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyclop
 	logger := makeLogger(conf)
 
 	logger.BindJSON("configuration", conf.String()).Debug("configuration")
+
+	warnDeprecatedDomainFronting(conf, logger)
 
 	eventStream, err := makeEventStream(conf, logger)
 	if err != nil {
@@ -343,7 +355,7 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 		Secret:                      conf.Secret,
 		Concurrency:                 conf.GetConcurrency(mtglib.DefaultConcurrency),
 		DomainFrontingPort:          conf.GetDomainFrontingPort(mtglib.DefaultDomainFrontingPort),
-		DomainFrontingIP:            conf.GetDomainFrontingHost(),
+		DomainFrontingHost:          conf.GetDomainFrontingHost(),
 		DomainFrontingProxyProtocol: conf.GetDomainFrontingProxyProtocol(false),
 		PreferIP:                    conf.PreferIP.Get(mtglib.DefaultPreferIP),
 		AutoUpdate:                  conf.AutoUpdate.Get(false),

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -343,7 +343,7 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 		Secret:                      conf.Secret,
 		Concurrency:                 conf.GetConcurrency(mtglib.DefaultConcurrency),
 		DomainFrontingPort:          conf.GetDomainFrontingPort(mtglib.DefaultDomainFrontingPort),
-		DomainFrontingIP:            conf.GetDomainFrontingIP(nil),
+		DomainFrontingIP:            conf.GetDomainFrontingHost(),
 		DomainFrontingProxyProtocol: conf.GetDomainFrontingProxyProtocol(false),
 		PreferIP:                    conf.PreferIP.Get(mtglib.DefaultPreferIP),
 		AutoUpdate:                  conf.AutoUpdate.Get(false),

--- a/internal/cli/simple_run.go
+++ b/internal/cli/simple_run.go
@@ -17,8 +17,9 @@ type SimpleRun struct {
 	Concurrency         uint64        `kong:"name='concurrency',short='c',default='8192',help='Max number of concurrent connection to proxy.'"`                        //nolint: lll
 	TCPBuffer           string        `kong:"name='tcp-buffer',short='b',default='4KB',help='Deprecated and ignored'"`                                                 //nolint: lll
 	PreferIP            string        `kong:"name='prefer-ip',short='i',default='prefer-ipv6',help='IP preference. By default we prefer IPv6 with fallback to IPv4.'"` //nolint: lll
-	DomainFrontingPort  uint64        `kong:"name='domain-fronting-port',short='p',default='443',help='A port to access for domain fronting.'"`                        //nolint: lll
-	DomainFrontingIP    string        `kong:"name='domain-fronting-ip',help='An IP address to use for domain fronting instead of resolving the hostname via DNS.'"`    //nolint: lll
+	DomainFrontingPort  uint64        `kong:"name='domain-fronting-port',short='p',default='443',help='A port to access for domain fronting.'"`                                                                  //nolint: lll
+	DomainFrontingHost  string        `kong:"name='domain-fronting-host',help='Hostname or IP to dial for domain fronting instead of resolving the secret hostname.'"`                                           //nolint: lll
+	DomainFrontingIP    string        `kong:"name='domain-fronting-ip',help='Deprecated: use --domain-fronting-host. Setting this flag logs a warning at startup and the value is ignored.'"`                    //nolint: lll
 	DOHIP               net.IP        `kong:"name='doh-ip',short='n',default='1.1.1.1',help='IP address of DNS-over-HTTP to use.'"`                                    //nolint: lll
 	Timeout             time.Duration `kong:"name='timeout',short='t',default='10s',help='Network timeout to use'"`                                                    //nolint: lll
 	Socks5Proxies       []string      `kong:"name='socks5-proxy',short='s',help='Socks5 proxies to use for network access.'"`                                          //nolint: lll
@@ -48,6 +49,15 @@ func (s *SimpleRun) Run(cli *CLI, version string) error { //nolint: cyclop,funle
 		return fmt.Errorf("incorrect domain-fronting-port: %w", err)
 	}
 
+	if s.DomainFrontingHost != "" {
+		if err := conf.DomainFronting.Host.Set(s.DomainFrontingHost); err != nil {
+			return fmt.Errorf("incorrect domain-fronting-host: %w", err)
+		}
+	}
+
+	// --domain-fronting-ip is deprecated; the value is parsed only so the
+	// runtime check in runProxy can detect it and emit the warn-and-ignore
+	// log message. The value never reaches the dial path.
 	if s.DomainFrontingIP != "" {
 		if err := conf.DomainFrontingIP.Set(s.DomainFrontingIP); err != nil {
 			return fmt.Errorf("incorrect domain-fronting-ip: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	PublicIPv6                  TypeIP          `json:"publicIpv6"`
 	DomainFronting              struct {
 		IP            TypeIP   `json:"ip"`
+		Host          TypeHost `json:"host"`
 		Port          TypePort `json:"port"`
 		ProxyProtocol TypeBool `json:"proxyProtocol"`
 	} `json:"domainFronting"`
@@ -118,6 +119,9 @@ func (c *Config) GetDomainFrontingPort(defaultValue uint) uint {
 }
 
 func (c *Config) GetDomainFrontingIP(defaultValue net.IP) string {
+	if host := c.DomainFronting.Host.Get(""); host != "" {
+		return host
+	}
 	if ip := c.DomainFronting.IP.Get(nil); ip != nil {
 		return ip.String()
 	}
@@ -138,6 +142,10 @@ func (c *Config) Validate() error {
 
 	if c.BindTo.Get("") == "" {
 		return fmt.Errorf("incorrect bind-to parameter %s", c.BindTo.String())
+	}
+
+	if c.DomainFronting.Host.Get("") != "" && c.DomainFronting.IP.Get(nil) != nil {
+		return fmt.Errorf("[domain-fronting] host and ip are mutually exclusive; pick one")
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,16 +118,7 @@ func (c *Config) GetDomainFrontingPort(defaultValue uint) uint {
 }
 
 func (c *Config) GetDomainFrontingHost() string {
-	if host := c.DomainFronting.Host.Get(""); host != "" {
-		return host
-	}
-	if ip := c.DomainFronting.IP.Get(nil); ip != nil {
-		return ip.String()
-	}
-	if ip := c.DomainFrontingIP.Get(nil); ip != nil {
-		return ip.String()
-	}
-	return ""
+	return c.DomainFronting.Host.Get("")
 }
 
 func (c *Config) GetDomainFrontingProxyProtocol(defaultValue bool) bool {
@@ -141,10 +132,6 @@ func (c *Config) Validate() error {
 
 	if c.BindTo.Get("") == "" {
 		return fmt.Errorf("incorrect bind-to parameter %s", c.BindTo.String())
-	}
-
-	if c.DomainFronting.Host.Get("") != "" && c.DomainFronting.IP.Get(nil) != nil {
-		return fmt.Errorf("[domain-fronting] host and ip are mutually exclusive; pick one")
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,8 @@ type Config struct {
 	PublicIPv4                  TypeIP          `json:"publicIpv4"`
 	PublicIPv6                  TypeIP          `json:"publicIpv6"`
 	DomainFronting              struct {
-		IP            TypeIP   `json:"ip"`
 		Host          TypeHost `json:"host"`
+		IP            TypeIP   `json:"ip"`
 		Port          TypePort `json:"port"`
 		ProxyProtocol TypeBool `json:"proxyProtocol"`
 	} `json:"domainFronting"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/url"
 
 	"github.com/9seconds/mtg/v2/mtglib"
@@ -118,14 +117,14 @@ func (c *Config) GetDomainFrontingPort(defaultValue uint) uint {
 	return c.DomainFrontingPort.Get(defaultValue)
 }
 
-func (c *Config) GetDomainFrontingIP(defaultValue net.IP) string {
+func (c *Config) GetDomainFrontingHost() string {
 	if host := c.DomainFronting.Host.Get(""); host != "" {
 		return host
 	}
 	if ip := c.DomainFronting.IP.Get(nil); ip != nil {
 		return ip.String()
 	}
-	if ip := c.DomainFrontingIP.Get(defaultValue); ip != nil {
+	if ip := c.DomainFrontingIP.Get(nil); ip != nil {
 		return ip.String()
 	}
 	return ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,17 @@ func (suite *ConfigTestSuite) TestString() {
 	suite.NotEmpty(conf.String())
 }
 
+func (suite *ConfigTestSuite) TestDomainFrontingHostOrIP() {
+	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
+	suite.NoError(err)
+
+	suite.NoError(conf.DomainFronting.Host.Set("fronting-backend"))
+	suite.NoError(conf.DomainFronting.IP.Set("10.0.0.10"))
+	suite.Error(conf.Validate())
+
+	suite.Equal("fronting-backend", conf.GetDomainFrontingIP(nil))
+}
+
 func TestConfig(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &ConfigTestSuite{})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,13 +74,14 @@ func (suite *ConfigTestSuite) TestString() {
 	suite.NotEmpty(conf.String())
 }
 
-func (suite *ConfigTestSuite) TestDomainFrontingHostAndIPMutuallyExclusive() {
+func (suite *ConfigTestSuite) TestDomainFrontingIPIgnoredWhenHostSet() {
 	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
 	suite.NoError(err)
 
 	suite.NoError(conf.DomainFronting.Host.Set("fronting-backend"))
 	suite.NoError(conf.DomainFronting.IP.Set("10.0.0.10"))
-	suite.Error(conf.Validate())
+	suite.NoError(conf.Validate())
+	suite.Equal("fronting-backend", conf.GetDomainFrontingHost())
 }
 
 func (suite *ConfigTestSuite) TestDomainFrontingHostFromTOML() {
@@ -97,11 +98,14 @@ func (suite *ConfigTestSuite) TestDomainFrontingHostAcceptsLiteralIP() {
 	suite.Equal("10.0.0.1", conf.GetDomainFrontingHost())
 }
 
-func (suite *ConfigTestSuite) TestDomainFrontingIPFromTOML() {
+func (suite *ConfigTestSuite) TestDomainFrontingIPIgnoredFromTOML() {
 	conf, err := config.Parse(suite.ReadConfig("domain_fronting_ip.toml"))
 	suite.NoError(err)
 	suite.NoError(conf.Validate())
-	suite.Equal("10.0.0.10", conf.GetDomainFrontingHost())
+	// Deprecated [domain-fronting].ip is parsed but never used to derive
+	// the dial target — the user must migrate to [domain-fronting].host.
+	suite.NotNil(conf.DomainFronting.IP.Get(nil))
+	suite.Equal("", conf.GetDomainFrontingHost())
 }
 
 func (suite *ConfigTestSuite) TestDomainFrontingNotSet() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,15 +74,34 @@ func (suite *ConfigTestSuite) TestString() {
 	suite.NotEmpty(conf.String())
 }
 
-func (suite *ConfigTestSuite) TestDomainFrontingHostOrIP() {
+func (suite *ConfigTestSuite) TestDomainFrontingHostAndIPMutuallyExclusive() {
 	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
 	suite.NoError(err)
 
 	suite.NoError(conf.DomainFronting.Host.Set("fronting-backend"))
 	suite.NoError(conf.DomainFronting.IP.Set("10.0.0.10"))
 	suite.Error(conf.Validate())
+}
 
-	suite.Equal("fronting-backend", conf.GetDomainFrontingIP(nil))
+func (suite *ConfigTestSuite) TestDomainFrontingHostFromTOML() {
+	conf, err := config.Parse(suite.ReadConfig("domain_fronting_host.toml"))
+	suite.NoError(err)
+	suite.NoError(conf.Validate())
+	suite.Equal("fronting-backend", conf.GetDomainFrontingHost())
+}
+
+func (suite *ConfigTestSuite) TestDomainFrontingIPFromTOML() {
+	conf, err := config.Parse(suite.ReadConfig("domain_fronting_ip.toml"))
+	suite.NoError(err)
+	suite.NoError(conf.Validate())
+	suite.Equal("10.0.0.10", conf.GetDomainFrontingHost())
+}
+
+func (suite *ConfigTestSuite) TestDomainFrontingNotSet() {
+	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
+	suite.NoError(err)
+	suite.NoError(conf.Validate())
+	suite.Equal("", conf.GetDomainFrontingHost())
 }
 
 func TestConfig(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,13 @@ func (suite *ConfigTestSuite) TestDomainFrontingHostFromTOML() {
 	suite.Equal("fronting-backend", conf.GetDomainFrontingHost())
 }
 
+func (suite *ConfigTestSuite) TestDomainFrontingHostAcceptsLiteralIP() {
+	conf, err := config.Parse(suite.ReadConfig("domain_fronting_host_ip.toml"))
+	suite.NoError(err)
+	suite.NoError(conf.Validate())
+	suite.Equal("10.0.0.1", conf.GetDomainFrontingHost())
+}
+
 func (suite *ConfigTestSuite) TestDomainFrontingIPFromTOML() {
 	conf, err := config.Parse(suite.ReadConfig("domain_fronting_ip.toml"))
 	suite.NoError(err)

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -25,6 +25,7 @@ type tomlConfig struct {
 	PublicIPv6                  string `toml:"public-ipv6" json:"publicIpv6,omitempty"`
 	DomainFronting              struct {
 		IP            string `toml:"ip" json:"ip,omitempty"`
+		Host          string `toml:"host" json:"host,omitempty"`
 		Port          uint   `toml:"port" json:"port,omitempty"`
 		ProxyProtocol bool   `toml:"proxy-protocol" json:"proxyProtocol,omitempty"`
 	} `toml:"domain-fronting" json:"domainFronting,omitempty"`

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -24,8 +24,8 @@ type tomlConfig struct {
 	PublicIPv4                  string `toml:"public-ipv4" json:"publicIpv4,omitempty"`
 	PublicIPv6                  string `toml:"public-ipv6" json:"publicIpv6,omitempty"`
 	DomainFronting              struct {
-		IP            string `toml:"ip" json:"ip,omitempty"`
 		Host          string `toml:"host" json:"host,omitempty"`
+		IP            string `toml:"ip" json:"ip,omitempty"`
 		Port          uint   `toml:"port" json:"port,omitempty"`
 		ProxyProtocol bool   `toml:"proxy-protocol" json:"proxyProtocol,omitempty"`
 	} `toml:"domain-fronting" json:"domainFronting,omitempty"`

--- a/internal/config/testdata/domain_fronting_host.toml
+++ b/internal/config/testdata/domain_fronting_host.toml
@@ -1,0 +1,5 @@
+secret = "7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"
+bind-to = "0.0.0.0:3128"
+
+[domain-fronting]
+host = "fronting-backend"

--- a/internal/config/testdata/domain_fronting_host_ip.toml
+++ b/internal/config/testdata/domain_fronting_host_ip.toml
@@ -1,0 +1,5 @@
+secret = "7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"
+bind-to = "0.0.0.0:3128"
+
+[domain-fronting]
+host = "10.0.0.1"

--- a/internal/config/testdata/domain_fronting_ip.toml
+++ b/internal/config/testdata/domain_fronting_ip.toml
@@ -1,0 +1,5 @@
+secret = "7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"
+bind-to = "0.0.0.0:3128"
+
+[domain-fronting]
+ip = "10.0.0.10"

--- a/internal/config/type_host.go
+++ b/internal/config/type_host.go
@@ -28,6 +28,9 @@ func (t *TypeHost) Set(value string) error {
 		return fmt.Errorf("incorrect host %q", value)
 	}
 
+	// At this point value is not a parsed IP (IPv6 literals returned
+	// above), so any remaining colon indicates a host:port form, which
+	// belongs in a separate field.
 	if strings.Contains(value, ":") {
 		return fmt.Errorf("host must not contain a port: %q", value)
 	}

--- a/internal/config/type_host.go
+++ b/internal/config/type_host.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// TypeHost is a non-empty string that is either a literal IP address
+// (IPv4 or IPv6) or a hostname suitable for DNS resolution. It does not
+// include a port — the port belongs in a separate field.
+type TypeHost struct {
+	Value string
+}
+
+func (t *TypeHost) Set(value string) error {
+	if value == "" {
+		return fmt.Errorf("host cannot be empty")
+	}
+
+	if net.ParseIP(value) != nil {
+		t.Value = value
+
+		return nil
+	}
+
+	if strings.ContainsAny(value, " \t\n/?#") {
+		return fmt.Errorf("incorrect host %q", value)
+	}
+
+	if strings.Contains(value, ":") {
+		return fmt.Errorf("host must not contain a port: %q", value)
+	}
+
+	t.Value = value
+
+	return nil
+}
+
+func (t TypeHost) Get(defaultValue string) string {
+	if t.Value == "" {
+		return defaultValue
+	}
+
+	return t.Value
+}
+
+func (t *TypeHost) UnmarshalText(data []byte) error {
+	return t.Set(string(data))
+}
+
+func (t TypeHost) MarshalText() ([]byte, error) {
+	return []byte(t.Value), nil
+}
+
+func (t TypeHost) String() string {
+	return t.Value
+}

--- a/internal/config/type_host_test.go
+++ b/internal/config/type_host_test.go
@@ -1,0 +1,77 @@
+package config_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/9seconds/mtg/v2/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type typeHostTestStruct struct {
+	Value config.TypeHost `json:"value"`
+}
+
+type TypeHostTestSuite struct {
+	suite.Suite
+}
+
+func (suite *TypeHostTestSuite) TestUnmarshalFail() {
+	testData := []string{
+		"",
+		"web:8443",
+		"http://example.com",
+		"example.com/path",
+		"two words",
+	}
+
+	for _, v := range testData {
+		data, err := json.Marshal(map[string]string{
+			"value": v,
+		})
+		suite.NoError(err)
+
+		suite.T().Run(v, func(t *testing.T) {
+			assert.Error(t, json.Unmarshal(data, &typeHostTestStruct{}))
+		})
+	}
+}
+
+func (suite *TypeHostTestSuite) TestUnmarshalOk() {
+	testData := []string{
+		"example.com",
+		"web",
+		"sub.example.com",
+		"127.0.0.1",
+		"2001:db8::1",
+	}
+
+	for _, v := range testData {
+		value := v
+
+		data, err := json.Marshal(map[string]string{
+			"value": value,
+		})
+		suite.NoError(err)
+
+		suite.T().Run(value, func(t *testing.T) {
+			testStruct := &typeHostTestStruct{}
+			assert.NoError(t, json.Unmarshal(data, testStruct))
+			assert.Equal(t, value, testStruct.Value.Get(""))
+		})
+	}
+}
+
+func (suite *TypeHostTestSuite) TestGet() {
+	value := config.TypeHost{}
+	suite.Equal("default", value.Get("default"))
+
+	suite.NoError(value.Set("example.com"))
+	suite.Equal("example.com", value.Get("default"))
+}
+
+func TestTypeHost(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &TypeHostTestSuite{})
+}

--- a/mtglib/proxy.go
+++ b/mtglib/proxy.go
@@ -344,6 +344,10 @@ func NewProxy(opts ProxyOpts) (*Proxy, error) {
 	logger := opts.getLogger("proxy")
 	updatersLogger := logger.Named("telegram-updaters")
 
+	if opts.DomainFrontingIP != "" {
+		logger.Warning("mtglib.ProxyOpts.DomainFrontingIP is deprecated and ignored; use DomainFrontingHost instead")
+	}
+
 	proxy := &Proxy{
 		ctx:                      ctx,
 		ctxCancel:                cancel,
@@ -355,7 +359,7 @@ func NewProxy(opts ProxyOpts) (*Proxy, error) {
 		eventStream:              opts.EventStream,
 		logger:                   logger,
 		domainFrontingPort:       opts.getDomainFrontingPort(),
-		domainFrontingHost:       opts.DomainFrontingIP,
+		domainFrontingHost:       opts.DomainFrontingHost,
 		tolerateTimeSkewness:     opts.getTolerateTimeSkewness(),
 		idleTimeout:              opts.getIdleTimeout(),
 		handshakeTimeout:         opts.getHandshakeTimeout(),

--- a/mtglib/proxy.go
+++ b/mtglib/proxy.go
@@ -30,7 +30,7 @@ type Proxy struct {
 	idleTimeout                 time.Duration
 	handshakeTimeout            time.Duration
 	domainFrontingPort          int
-	domainFrontingIP            string
+	domainFrontingHost          string
 	domainFrontingProxyProtocol bool
 	workerPool                  *ants.PoolWithFunc
 	telegram                    *dc.Telegram
@@ -48,11 +48,12 @@ type Proxy struct {
 }
 
 // DomainFrontingAddress returns a host:port pair for a fronting domain.
-// If DomainFrontingIP is set, it is used instead of resolving the hostname.
+// If a fronting host (literal IP or hostname) is configured, it is used
+// instead of resolving the secret's hostname.
 func (p *Proxy) DomainFrontingAddress() string {
 	host := p.secret.Host
-	if p.domainFrontingIP != "" {
-		host = p.domainFrontingIP
+	if p.domainFrontingHost != "" {
+		host = p.domainFrontingHost
 	}
 
 	return net.JoinHostPort(host, strconv.Itoa(p.domainFrontingPort))
@@ -354,7 +355,7 @@ func NewProxy(opts ProxyOpts) (*Proxy, error) {
 		eventStream:              opts.EventStream,
 		logger:                   logger,
 		domainFrontingPort:       opts.getDomainFrontingPort(),
-		domainFrontingIP:         opts.DomainFrontingIP,
+		domainFrontingHost:       opts.DomainFrontingIP,
 		tolerateTimeSkewness:     opts.getTolerateTimeSkewness(),
 		idleTimeout:              opts.getIdleTimeout(),
 		handshakeTimeout:         opts.getHandshakeTimeout(),

--- a/mtglib/proxy_opts.go
+++ b/mtglib/proxy_opts.go
@@ -105,11 +105,14 @@ type ProxyOpts struct {
 	// This is an optional setting.
 	DomainFrontingPort uint
 
-	// DomainFrontingIP is an IP address to use when connecting to the fronting
-	// domain instead of resolving the hostname from the secret via DNS.
+	// DomainFrontingIP is the address to use when connecting to the fronting
+	// domain instead of resolving the hostname from the secret via DNS. It
+	// can be a literal IP or a hostname; hostnames are resolved at dial time
+	// via the native dialer (which honours dual-stack and Happy Eyeballs).
 	//
-	// This is useful when DNS resolution of the fronting host is blocked.
-	// The hostname from the secret is still used for SNI in the TLS handshake.
+	// This is useful when DNS resolution of the secret's hostname is blocked
+	// or loops back to this server. The hostname from the secret is still
+	// used for SNI in the TLS handshake.
 	//
 	// This is an optional setting.
 	DomainFrontingIP string

--- a/mtglib/proxy_opts.go
+++ b/mtglib/proxy_opts.go
@@ -105,16 +105,24 @@ type ProxyOpts struct {
 	// This is an optional setting.
 	DomainFrontingPort uint
 
-	// DomainFrontingIP is the address to use when connecting to the fronting
-	// domain instead of resolving the hostname from the secret via DNS. It
-	// can be a literal IP or a hostname; hostnames are resolved at dial time
-	// via the native dialer (which honours dual-stack and Happy Eyeballs).
+	// DomainFrontingHost is the address to use when connecting to the
+	// fronting domain instead of resolving the hostname from the secret via
+	// DNS. It can be a literal IP or a hostname; hostnames are resolved at
+	// dial time via the native dialer (which honours dual-stack and Happy
+	// Eyeballs).
 	//
 	// This is useful when DNS resolution of the secret's hostname is blocked
 	// or loops back to this server. The hostname from the secret is still
 	// used for SNI in the TLS handshake.
 	//
 	// This is an optional setting.
+	DomainFrontingHost string
+
+	// DomainFrontingIP previously held the dial target for the fronting
+	// domain. The setting is no longer honoured: setting it logs a warning
+	// at proxy startup and the value is dropped.
+	//
+	// Deprecated: use DomainFrontingHost. Setting this field has no effect.
 	DomainFrontingIP string
 
 	// DomainFrontingProxyProtocol is used if communication between upstream


### PR DESCRIPTION
## Summary

Today `[domain-fronting].ip` only accepts a literal IP (`TypeIP` →
`net.ParseIP`). When mtg sits behind an SNI router (HAProxy, etc.)
whose DNS for the secret's hostname points back at the same host,
mtg's default fronting behaviour resolves that hostname and dials
itself, looping. Working around this in deployment requires pinning a
static docker container IP and subnet so the literal-IP field can
target the fronting backend directly.

This adds a sibling `[domain-fronting].host` field that accepts either
a hostname or an IP. Hostnames are resolved at dial time by the native
dialer (which already handles dual-stack / Happy Eyeballs), so an A+AAAA
docker-DNS or normal DNS record reaches the right backend address
family for IPv4 and IPv6 clients without a static pin.

`ip` semantics are unchanged. Setting both `host` and `ip` is rejected
in `Validate()`.

## API stability

`mtglib.ProxyOpts.DomainFrontingIP` is still a plain `string`. The
dial path already passes it to `net.JoinHostPort` + `DialContext`,
both of which accept hostnames. Only the field's doc comment was
clarified — no signature change, no new public symbols in `mtglib`.

`internal/cli/run_proxy.go`, `simple_run.go` and `doctor.go` all
continue to work via the existing `Config.GetDomainFrontingIP()`
helper, which now prefers `Host` over `IP` over the legacy flat
`domain-fronting-ip`.

## What's added

- `internal/config/type_host.go` — `TypeHost` (accepts hostname or IP,
  rejects empty, `host:port`, URLs, whitespace).
- `internal/config/type_host_test.go` — Get / UnmarshalOk / UnmarshalFail.
- `internal/config/config_test.go` — `TestDomainFrontingHostOrIP`
  covering precedence and mutual-exclusion.
- `[domain-fronting]` section of `example.config.toml` updated to
  document `host` alongside `ip`.

## Motivation

Direct follow-up to a review thread on #478, which currently works
around the literal-IP restriction with a pinned docker subnet. Once
this lands, that PR collapses to ~3 lines (`host = "web"`) and its
IPv6 PROXY-protocol-family caveat goes away.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] New `TypeHost` tests pass (5 accept, 5 reject)
- [x] New `TestDomainFrontingHostOrIP` covers Validate() rejection of both-set and Host-wins precedence