### PR TITLE
Do not use custom DNS resolver to dial proxy upstreams

### DIFF
--- a/network/v2/proxy_network.go
+++ b/network/v2/proxy_network.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -39,8 +40,23 @@ func (p proxyNetwork) MakeHTTPClient(
 	return p.Network.MakeHTTPClient(dialFunc)
 }
 
+// proxyServerDialer is the dialer used to connect to a SOCKS upstream. It
+// copies timeout and fallback-delay from the base dialer but drops the custom
+// Resolver: the user-supplied DoT/DoH resolver is for bypassing DPI on public
+// names (Telegram DCs, fronting host), whereas SOCKS upstream addresses are
+// usually internal (docker compose, k8s, /etc/hosts) and must be resolved by
+// the system resolver. See https://github.com/9seconds/mtg/issues/439.
+func proxyServerDialer(base mtglib.Network) *net.Dialer {
+	nd := base.NativeDialer()
+
+	return &net.Dialer{
+		Timeout:       nd.Timeout,
+		FallbackDelay: nd.FallbackDelay,
+	}
+}
+
 func NewProxyNetwork(base mtglib.Network, proxyURL *url.URL) (*proxyNetwork, error) {
-	socks, err := proxy.FromURL(proxyURL, base.NativeDialer())
+	socks, err := proxy.FromURL(proxyURL, proxyServerDialer(base))
 	if err != nil {
 		return nil, fmt.Errorf("cannot build proxy dialer: %w", err)
 	}

--- a/network/v2/proxy_network_internal_test.go
+++ b/network/v2/proxy_network_internal_test.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// Regression test for https://github.com/9seconds/mtg/issues/439: the dialer
+// used to reach a SOCKS upstream must not inherit the user-supplied DoT/DoH
+// resolver, otherwise internal names (docker compose, k8s, /etc/hosts) fail
+// to resolve through a public resolver that does not know them.
+func TestProxyServerDialerDropsCustomResolver(t *testing.T) {
+	customResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return nil, errors.New("custom resolver must not be queried for SOCKS upstream")
+		},
+	}
+
+	base := New(
+		customResolver,
+		"mtg-test",
+		7*time.Second,
+		0,
+		0,
+		DefaultKeepAliveConfig,
+	)
+
+	if base.NativeDialer().Resolver != customResolver {
+		t.Fatalf("base.NativeDialer().Resolver = %v, want custom resolver", base.NativeDialer().Resolver)
+	}
+
+	d := proxyServerDialer(base)
+
+	if d.Resolver != nil {
+		t.Errorf("proxyServerDialer().Resolver = %v, want nil (must use OS resolver)", d.Resolver)
+	}
+
+	if d.Timeout != base.NativeDialer().Timeout {
+		t.Errorf("proxyServerDialer().Timeout = %v, want %v", d.Timeout, base.NativeDialer().Timeout)
+	}
+
+	if d.FallbackDelay != base.NativeDialer().FallbackDelay {
+		t.Errorf("proxyServerDialer().FallbackDelay = %v, want %v", d.FallbackDelay, base.NativeDialer().FallbackDelay)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #439.

When `[network] dns = "tls://..."` (or `"https://..."`) is set, the resulting `*net.Resolver` gets attached to the base network's `NativeDialer` and was previously also handed to `golang.org/x/net/proxy.FromURL` via `NewProxyNetwork`. As a result, the SOCKS5 client used the user's DoT/DoH resolver to look up the **SOCKS server's own hostname** (e.g. `xray` inside a docker compose stack). Public DoT/DoH resolvers don't know docker-compose service names, k8s service DNS, `/etc/hosts` entries, or corporate split-horizon DNS, so the upstream lookup returned NXDOMAIN and the proxy chain broke with the misleading

```
socks connect tcp xray:10808->149.154.175.50:443: dial tcp: lookup xray on 127.0.0.11:53: no such host
```

The custom DNS resolver was added to bypass DPI poisoning when resolving public censored names (Telegram DCs, SNI/fronting host). Proxy server addresses are almost always internal and should be resolved via the system resolver instead.

## Change

Introduces `proxyServerDialer` in `network/v2/proxy_network.go`: it copies `Timeout` and `FallbackDelay` from the base dialer but leaves `Resolver == nil`, and is the dialer fed to `proxy.FromURL`. Behavior for users without `[network] dns` is unchanged (their resolver was `nil` already).

## Test plan

- [x] New `TestProxyServerDialerDropsCustomResolver` in `proxy_network_internal_test.go` builds a base network with a deliberately-failing custom resolver and asserts the SOCKS upstream dialer does not inherit it.
- [x] `go test ./network/v2/...` — all tests pass, including the existing SOCKS proxy suite.
- [x] `go vet ./...` clean.
- [x] Manually reproduced the original failure on `nineseconds/mtg:2` + `xray-core` docker compose with `dns = "tls://1.1.1.1"` and verified this fix makes `mtg doctor` pass without `extra_hosts` workarounds.