### PR TITLE
doctor: add --skip-native-check flag

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -69,7 +69,8 @@ var (
 type Doctor struct {
 	conf *config.Config
 
-	ConfigPath string `kong:"arg,required,type='existingfile',help='Path to the configuration file.',name='config-path'"` //nolint: lll
+	ConfigPath      string `kong:"arg,required,type='existingfile',help='Path to the configuration file.',name='config-path'"` //nolint: lll
+	SkipNativeCheck bool   `kong:"help='Skip the native network connectivity check (useful when proxy chaining is configured and direct egress is not expected to work).',name='skip-native-check'"` //nolint: lll
 }
 
 func (d *Doctor) Run(cli *CLI, version string) error {
@@ -106,7 +107,11 @@ func (d *Doctor) Run(cli *CLI, version string) error {
 	)
 
 	fmt.Println("Validate native network connectivity")
-	everythingOK = d.checkNetwork(base) && everythingOK
+	if d.SkipNativeCheck {
+		fmt.Println("  ⏭ Skipped (--skip-native-check)")
+	} else {
+		everythingOK = d.checkNetwork(base) && everythingOK
+	}
 
 	for _, url := range conf.Network.Proxies {
 		value, err := network.NewProxyNetwork(base, url.Get(nil))


### PR DESCRIPTION
## Summary

Adds a `--skip-native-check` flag to `mtg doctor` that skips the *Validate native network connectivity* section.

When proxy chaining is configured (\`network.proxies\`), the native dialer is intentionally not used to reach Telegram DCs, so this section currently times out for every DC — roughly 10s × 6 DCs = ~60s of dead air before the rest of the doctor output continues.

The check is still useful by default (it confirms the host can reach Telegram directly when no proxy is configured), so the behavior is opt-in.

Sample output with the flag set:

\`\`\`
Validate native network connectivity
  ⏭ Skipped (--skip-native-check)
Validate network connectivity with proxy ...
  ✅ DC 1
  ...
\`\`\`

Scope is intentionally narrow — only \`checkNetwork(base)\` is gated. \`checkFrontingDomain\` also uses the native dialer, but it is conceptually distinct (it tests whether the proxy host itself can reach the fronting domain, which is still meaningful under chain-mode), so it is left untouched.

Closes #482.

## Test plan

- [x] \`go vet ./internal/cli/\` clean
- [x] \`go build ./...\` clean
- [ ] Manual verification: run \`mtg doctor --skip-native-check config.toml\` against a chained-proxy config, confirm the native section is skipped and the rest of the report runs normally