### PR TITLE
doctor: run DC connectivity probes in parallel

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -225,11 +225,14 @@ func (d *Doctor) checkNetwork(ntw mtglib.Network) bool {
 
 	var wg sync.WaitGroup
 	for i, dc := range dcs {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					errs[i] = fmt.Errorf("panic: %v", r)
+				}
+			}()
 			errs[i] = d.checkNetworkAddresses(ntw, essentials.TelegramCoreAddresses[dc])
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -220,18 +221,29 @@ func (d *Doctor) checkNetwork(ntw mtglib.Network) bool {
 	dcs := slices.Collect(maps.Keys(essentials.TelegramCoreAddresses))
 	slices.Sort(dcs)
 
+	errs := make([]error, len(dcs))
+
+	var wg sync.WaitGroup
+	for i, dc := range dcs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = d.checkNetworkAddresses(ntw, essentials.TelegramCoreAddresses[dc])
+		}()
+	}
+	wg.Wait()
+
 	ok := true
 
-	for _, dc := range dcs {
-		err := d.checkNetworkAddresses(ntw, essentials.TelegramCoreAddresses[dc])
-		if err == nil {
+	for i, dc := range dcs {
+		if errs[i] == nil {
 			tplODCConnect.Execute(os.Stdout, map[string]any{ //nolint: errcheck
 				"dc": dc,
 			})
 		} else {
 			tplEDCConnect.Execute(os.Stdout, map[string]any{ //nolint: errcheck
 				"dc":    dc,
-				"error": err,
+				"error": errs[i],
 			})
 			ok = false
 		}


### PR DESCRIPTION
## Summary

mtg doctor's *Validate native network connectivity* section dials each Telegram DC sequentially, with a 10s timeout per DC. When egress to Telegram is broken (e.g. host has no native route, only proxy chain) this means waiting ~60s (6 DCs × 10s) for the section to finish.

This PR runs the per-DC dials concurrently using \`sync.WaitGroup\`, collects results, then prints them in DC order so the output is unchanged. Worst case becomes a single ~10s window.

No timeout is changed; this is purely a concurrency change. Same applies regardless of whether \`network.proxies\` is configured — it speeds up the broken-egress case for everyone.

Refs #482. Pairs nicely with #484 (which makes the section skippable entirely) but is independent and useful on its own.

## Test plan

- [x] go vet ./internal/cli/ clean
- [x] go build ./... clean
- [ ] Manual: run \`mtg doctor\` against a config where Telegram DCs are unreachable; confirm the section completes in ~10s instead of ~60s, and DC results print in numeric order (1, 2, 3, 4, 5, 203)