### PR TITLE
add support for unprivileged podman container

### DIFF
--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -23,16 +23,18 @@ services:
       - "443:443"
       - "80:80"
     volumes:
-      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
     depends_on:
       - mtg
       - web
     restart: unless-stopped
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=80
 
   mtg:
     image: nineseconds/mtg:2
     volumes:
-      - ./mtg-config.toml:/config/config.toml:ro
+      - ./mtg-config.toml:/config/config.toml:ro,Z
     expose:
       - "3128"
     restart: unless-stopped
@@ -40,9 +42,9 @@ services:
   web:
     image: caddy:alpine
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro,Z
       - caddy_data:/data
-      - ./www:/srv:ro
+      - ./www:/srv:ro,Z
     expose:
       - "80"
       - "8443"


### PR DESCRIPTION
Fix permission denied error for containerized apps reading configs exposed via volumes.
Also make it possible to use port 80 in the fronted.

```console
$ podman-compose up --abort-on-container-exit
[mtg]     | mtg: error: cannot init config: cannot read config file: open /config/config.toml: permission denied
..
[web]     | Error: reading config from file: open /etc/caddy/Caddyfile: permission denied
..
[haproxy] | [ALERT]    (1) : config : Could not open configuration file /usr/local/etc/haproxy/haproxy.cfg : Permission denied
```

@dolonet 