### PR TITLE
doctor: add --skip-native-check flag

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -69,7 +69,8 @@ var (
 type Doctor struct {
 	conf *config.Config
 
-	ConfigPath string `kong:"arg,required,type='existingfile',help='Path to the configuration file.',name='config-path'"` //nolint: lll
+	ConfigPath      string `kong:"arg,required,type='existingfile',help='Path to the configuration file.',name='config-path'"` //nolint: lll
+	SkipNativeCheck bool   `kong:"help='Skip the native network connectivity check (useful when proxy chaining is configured and direct egress is not expected to work).',name='skip-native-check'"` //nolint: lll
 }
 
 func (d *Doctor) Run(cli *CLI, version string) error {
@@ -106,7 +107,11 @@ func (d *Doctor) Run(cli *CLI, version string) error {
 	)
 
 	fmt.Println("Validate native network connectivity")
-	everythingOK = d.checkNetwork(base) && everythingOK
+	if d.SkipNativeCheck {
+		fmt.Println("  ⏭ Skipped (--skip-native-check)")
+	} else {
+		everythingOK = d.checkNetwork(base) && everythingOK
+	}
 
 	for _, url := range conf.Network.Proxies {
 		value, err := network.NewProxyNetwork(base, url.Get(nil))


### PR DESCRIPTION
## Summary

Adds a `--skip-native-check` flag to `mtg doctor` that skips the *Validate native network connectivity* section.

When proxy chaining is configured (`network.proxies`), the native dialer is intentionally not the path used to reach Telegram DCs, so this section currently times out for every DC. #485 makes those dials concurrent (worst case ~10s instead of ~60s), but for users who know native egress is broken by design, even a single 10s window is wasted time on every `mtg doctor` invocation.

The check is still useful by default (it confirms the host can reach Telegram directly when no proxy is configured), so the behavior is opt-in.

Sample output with the flag set:

```
Validate native network connectivity
  ⏭ Skipped (--skip-native-check)
Validate network connectivity with proxy ...
  ✅ DC 1
  ...
```

Scope is intentionally narrow — only `checkNetwork(base)` is gated. `checkFrontingDomain` also uses the native dialer, but it is conceptually distinct (it tests whether the proxy host itself can reach the fronting domain, which is still meaningful under chain-mode), so it is left untouched.

This re-sends the same diff as the previously closed #484 — closed it prematurely thinking #485 alone would be enough; the issue reporter clarified in https://github.com/9seconds/mtg/issues/482#issuecomment-4342151748 that both the speedup and the skip option are wanted. Independent of #485 and can land in either order.

Closes #482.

## Test plan

- [x] Diff is byte-for-byte identical to closed #484 which was `mergeable_state: clean`
- [ ] Manual verification: run `mtg doctor --skip-native-check config.toml` against a chained-proxy config, confirm the native section is skipped and the rest of the report runs normally