### PR TITLE
compose: mtg: add hostname for host access from container

### DIFF
--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     expose:
       - "3128"
     restart: unless-stopped
+    extra_hosts:
+      - "host.containers.internal:host-gateway"
 
   web:
     image: caddy:alpine


### PR DESCRIPTION
Might be needed for local chained proxy setup.

> У контейнеров есть специальное имя для локального интерфейса _хоста_ - `host.containers.internal` или `host.docker.internal`.
> 
> Если podman добавляет оба эти хоста по-умолчанию, то докер этого не делает и ему требуется указать явно, например:
> ```yml
> extra_hosts:
>   - "host.containers.internal:host-gateway"
> ```
> Думаю, можно добавить это в любом случае, не помешает, зато избавит от головной боли тех, кому это нужно.
> Могу сделать PR. 

 _Originally posted by @bam80 in [#439](https://github.com/9seconds/mtg/issues/439#issuecomment-4367116093)_

@dolonet 