### PR TITLE
contrib/sni-router: read $DOMAIN from env in haproxy.cfg

### DIFF
--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -27,10 +27,9 @@ natural and passive DPI has nothing to flag.
 # 2. Generate an mtg secret:
 docker run --rm nineseconds/mtg:2 generate-secret --hex YOUR_DOMAIN
 
-# 3. Edit the config files:
-#    - mtg-config.toml  →  paste the secret
-#    - haproxy.cfg       →  replace "example.com" in the SNI ACL
-#    - .env or export    →  DOMAIN=your.domain
+# 3. Configure:
+#    - .env (or export)  →  DOMAIN=your.domain   # used by HAProxy + Caddy
+#    - mtg-config.toml   →  paste the secret
 
 # 4. (Optional) put your site content into www/
 
@@ -83,7 +82,7 @@ domain's DNS A/AAAA record points to this server before starting.
 | File | Purpose |
 |---|---|
 | `docker-compose.yml` | Service definitions |
-| `haproxy.cfg` | SNI routing rules — **edit the domain** |
+| `haproxy.cfg` | SNI routing rules (reads `$DOMAIN` from the environment) |
 | `mtg-config.toml` | mtg proxy config — **paste your secret** |
 | `Caddyfile` | Web server config (auto-HTTPS) |
 | `www/` | Static site content served by Caddy |

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -9,10 +9,12 @@
 # SNI/IP because the domain resolves to this server's IP.
 #
 # Quick start:
-#   1. Set YOUR_DOMAIN below (and in mtg-config.toml)
-#   2. docker compose up -d
-#   3. mtg generate-secret YOUR_DOMAIN   -> put it in mtg-config.toml
-#   4. docker compose restart mtg
+#   1. Set DOMAIN in a .env file next to this one (or export it)
+#   2. mtg generate-secret YOUR_DOMAIN   -> paste into mtg-config.toml
+#   3. docker compose up -d
+#
+# DOMAIN is forwarded to both Caddy (TLS cert) and HAProxy (SNI ACL),
+# so the SNI/cert/secret all line up from a single source.
 #
 # See BEST_PRACTICES.md and the project wiki for background.
 
@@ -24,6 +26,8 @@ services:
       - "80:80"
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
+    environment:
+      DOMAIN: ${DOMAIN:-example.com}
     depends_on:
       - mtg
       - web

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -18,6 +18,9 @@
 #
 # See BEST_PRACTICES.md and the project wiki for background.
 
+x-domain-env: &domain-env
+  DOMAIN: ${DOMAIN:-example.com}
+
 services:
   haproxy:
     image: haproxy:lts-alpine
@@ -26,8 +29,7 @@ services:
       - "80:80"
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
-    environment:
-      DOMAIN: ${DOMAIN:-example.com}
+    environment: *domain-env
     depends_on:
       - mtg
       - web
@@ -54,8 +56,7 @@ services:
     expose:
       - "80"
       - "8443"
-    environment:
-      DOMAIN: ${DOMAIN:-example.com}
+    environment: *domain-env
     restart: unless-stopped
 
 volumes:

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -29,7 +29,8 @@ services:
       - "80:80"
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
-    environment: *domain-env
+    environment:
+      <<: *domain-env
     depends_on:
       - mtg
       - web
@@ -56,7 +57,8 @@ services:
     expose:
       - "80"
       - "8443"
-    environment: *domain-env
+    environment:
+      <<: *domain-env
     restart: unless-stopped
 
 volumes:

--- a/contrib/sni-router/haproxy.cfg
+++ b/contrib/sni-router/haproxy.cfg
@@ -39,9 +39,10 @@ frontend tls
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
 
-    # Route Telegram clients to mtg.
-    # Replace "example.com" with the domain from your mtg secret.
-    use_backend mtg if { req_ssl_sni -i example.com }
+    # Route Telegram clients to mtg.  The domain is read from the $DOMAIN
+    # environment variable (forwarded by docker-compose), so it stays in
+    # sync with Caddy and there is no per-deploy edit to this file.
+    use_backend mtg if { req_ssl_sni -i "${DOMAIN}" }
 
     default_backend web
 

--- a/contrib/sni-router/mtg-config.toml
+++ b/contrib/sni-router/mtg-config.toml
@@ -1,8 +1,8 @@
 # Minimal mtg configuration for the SNI-router setup.
 #
-# 1. Generate a secret:  mtg generate-secret --hex example.com
-# 2. Paste it below.
-# 3. Replace example.com with your actual domain everywhere.
+# 1. Generate a secret:  mtg generate-secret --hex <your.domain>
+# 2. Paste it into the `secret` field below.
+# 3. Set DOMAIN=<your.domain> in .env (HAProxy + Caddy pick it up).
 
 secret = "PASTE_YOUR_SECRET_HERE"
 bind-to = "0.0.0.0:3128"


### PR DESCRIPTION
## Summary

Closes #501. Removes one of the two runtime domain-sync points in `contrib/sni-router/`: HAProxy now reads the SNI hostname from the `$DOMAIN` environment variable instead of carrying a hardcoded `example.com` in `haproxy.cfg`.

The user-edit footprint at install time becomes:

1. Set `DOMAIN` in `.env` (or `export` it) — used by Caddy *and* HAProxy.
2. Generate the mtg secret with `mtg generate-secret $DOMAIN` and paste it into `mtg-config.toml`.

`mtg-config.toml`'s secret still embeds the domain in its bytes (per `mtglib/secret.go`), so it remains a one-time generated value rather than something to keep in sync — README is updated to reflect this.

## Changes

- `haproxy.cfg`: literal `example.com` → `"${DOMAIN}"`. HAProxy has supported environment-variable substitution in config strings since 1.6.
- `docker-compose.yml`: forward `DOMAIN` into the `haproxy` service's environment, mirroring what the `web`/Caddy service already does. Default kept as `example.com` so `docker compose config` still parses with no `.env`.
- `README.md` + docker-compose comment block: drop the obsolete "edit haproxy.cfg" step from quick start; update the file table.

## Test plan

- [ ] `DOMAIN=example.org docker compose up -d` → HAProxy ACL resolves to `example.org`, Caddy provisions a cert for `example.org`.
- [ ] `docker compose config` shows `DOMAIN: example.org` on the `haproxy` service.
- [ ] Without `.env`, fallback `example.com` is used; haproxy starts cleanly.
- [ ] Telegram client with the matching FakeTLS secret still routes to mtg; everything else lands on Caddy.