### PR TITLE
docs: clarify bind-to syntax in example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -20,7 +20,12 @@ debug = true
 # should either be base64-encoded or starts with ee.
 secret = "ee367a189aee18fa31c190054efd4a8e9573746f726167652e676f6f676c65617069732e636f6d"
 
-# Host:port pair to run proxy on.
+# Host:port pair to run proxy on (required).
+# The host part must be a literal IP address; hostnames and "*" are rejected.
+#   - IPv4 only:
+#     "0.0.0.0:3128"
+#   - dual-stack (IPv4 + IPv6) on Linux, macOS, FreeBSD, Windows:
+#     "[::]:3128"
 bind-to = "0.0.0.0:3128"
 
 # This defines what types of traffic mtg listens to. If you are not sure,


### PR DESCRIPTION
## Summary

Expands the one-line `bind-to` comment in `example.config.toml` to spell out:

- the host part must be a literal IP (no `*`, no hostnames),
- the two common forms users actually want: `0.0.0.0:port` (IPv4-only) and `[::]:port` (dual-stack).

Format follows the existing bullet-list style used by `prefer-ip` (and the `dns` block in stats config) — `#   - "value":` with the description indented on the next line. The dual-stack note is qualified by platform (Linux/macOS/FreeBSD/Windows) to avoid implying universal behavior; OpenBSD's kernel forces `IPV6_V6ONLY=1` regardless of Go's socket option.

## Why

Resolves recurring confusion — most recently #499 — about whether `[::]:port` listens on both IPv4 and IPv6, and why `*:port` is rejected with `host is not an IP address`. Currently the only authoritative answer lives in the wiki FAQ; making the config example self-explanatory keeps the source of truth in one place.

## Diff

```diff
-# Host:port pair to run proxy on.
+# Host:port pair to run proxy on. The host part must be a literal IP
+# address; hostnames and "*" are rejected.
+#   - "0.0.0.0:3128":
+#     IPv4 only
+#   - "[::]:3128":
+#     dual-stack (IPv4 + IPv6) on Linux, macOS, FreeBSD, Windows
 bind-to = "0.0.0.0:3128"
```

Docs-only, no behavior change.

Closes #499. Related: #500 (proposes `[::]:` as the default in `contrib/sni-router/mtg-config.toml` — same theme, different file; orthogonal change).