### PR TITLE
docs: mark prefer-ipv6 as the default in example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -39,7 +39,7 @@ concurrency = 8192
 # Sometimes you want to enforce mtg to use some types of
 # IP connectivity to Telegram. We have 4 modes:
 #   - prefer-ipv6:
-#     We can use both ipv4 and ipv6 but ipv6 has a preference
+#     We can use both ipv4 and ipv6 but ipv6 has a preference (default)
 #   - prefer-ipv4:
 #     We can use both ipv4 and ipv6 but ipv4 has a preference
 #   - only-ipv6:


### PR DESCRIPTION
Closes #492.

Adds a `(default)` marker next to `prefer-ipv6` in the `prefer-ip` docs of `example.config.toml`. Without it, the four modes read as equally weighted and the surrounding text doesn't say which one applies when the key is omitted.

Default itself lives in `mtglib/init.go` (`DefaultPreferIP = "prefer-ipv6"`) and is consumed via `conf.PreferIP.Get(mtglib.DefaultPreferIP)` in `internal/cli/run_proxy.go`.

Docs-only, no behavior change.