### PR TITLE
doctor: surface both public IPs in SNI-DNS mismatch message

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,7 +56,7 @@ var (
 		template.New("").Parse("  ✅ IP address {{ .ip }} matches secret hostname {{ .hostname }}\n"),
 	)
 	tplEDNSSNIMatch = template.Must(
-		template.New("").Parse("  ❌ Hostname {{ .hostname }} {{ if .resolved }}is resolved to {{ .resolved }} addresses, not {{ if .ip4 }}{{ .ip4 }}{{ else }}{{ .ip6 }}{{ end }}{{ else }}cannot be resolved to any host{{ end }}\n"),
+		template.New("").Parse("  ❌ Hostname {{ .hostname }} {{ if .resolved }}resolves to {{ .resolved }}, but the proxy's public IP is {{ if .ip4 }}{{ .ip4 }}{{ else }}<not detected>{{ end }} (IPv4) / {{ if .ip6 }}{{ .ip6 }}{{ else }}<not detected>{{ end }} (IPv6) — none of the resolved addresses match{{ else }}cannot be resolved to any host{{ end }}\n"),
 	)
 
 	tplOFrontingDomain = template.Must(


### PR DESCRIPTION
Closes #486.

## What

Reword `tplEDNSSNIMatch` so the SNI-DNS mismatch line lists both detected public addresses (or `<not detected>` when missing), making dual-stack gaps obvious.

## Why

The previous message read "Hostname X is resolved to Y addresses, not Z" with Z being either the detected IPv4 or IPv6 (whichever non-nil came first). For the common "AAAA-only DNS, no `public-ipv6` set" case the line printed "not <IPv4>", silently hiding the fact that the IPv6 side wasn't detected at all — exactly the confusion in #486.

## Output sample

Old:
```
❌ Hostname example.com is resolved to "2001:db8::1" addresses, not 1.2.3.4
```

New:
```
❌ Hostname example.com resolves to "2001:db8::1", but the proxy's public IP is 1.2.3.4 (IPv4) / <not detected> (IPv6) — none of the resolved addresses match
```

The action ("set `public-ipv6` or fix DNS") becomes obvious from the message itself.

## Tests

`go vet ./...` clean, `go build ./...` clean. No test files in `internal/cli/`. Pure template/message change, no behavior change beyond the rendered string.