### PR TITLE
simple-run: add --proxy-protocol-listener flag

### DIFF
--- a/internal/cli/simple_run.go
+++ b/internal/cli/simple_run.go
@@ -24,6 +24,8 @@ type SimpleRun struct {
 	Timeout             time.Duration `kong:"name='timeout',short='t',default='10s',help='Network timeout to use'"`                                                    //nolint: lll
 	Socks5Proxies       []string      `kong:"name='socks5-proxy',short='s',help='Socks5 proxies to use for network access.'"`                                          //nolint: lll
 	AntiReplayCacheSize string        `kong:"name='antireplay-cache-size',short='a',default='1MB',help='A size of anti-replay cache to use.'"`                         //nolint: lll
+
+	ProxyProtocolListener bool `kong:"name='proxy-protocol-listener',help='Expect PROXY protocol (v1 or v2) headers on the listener. Use when mtg sits behind HAProxy, nginx stream, or similar.'"` //nolint: lll
 }
 
 func (s *SimpleRun) Run(cli *CLI, version string) error { //nolint: cyclop,funlen
@@ -97,6 +99,7 @@ func (s *SimpleRun) Run(cli *CLI, version string) error { //nolint: cyclop,funle
 	conf.Debug.Value = s.Debug
 	conf.AllowFallbackOnUnknownDC.Value = true
 	conf.Defense.AntiReplay.Enabled.Value = true
+	conf.ProxyProtocolListener.Value = s.ProxyProtocolListener
 
 	if err := conf.Validate(); err != nil {
 		return fmt.Errorf("invalid result configuration: %w", err)


### PR DESCRIPTION
Mirrors the existing `proxy-protocol-listener` TOML option as a CLI flag on `simple-run`, so deployments fronted by HAProxy / nginx stream don't have to drop back to a config file just to enable PROXY-protocol parsing on the listener.

With this flag, the compose recipe discussed in #502 collapses to a single line with no `mtg-config.toml` in the repo:

```yaml
mtg:
  command: simple-run 0.0.0.0:3128 ${MTG_SECRET} --proxy-protocol-listener
```

Per your "yes, the good idea" in https://github.com/9seconds/mtg/issues/502#issuecomment-4438700228. Closes the practical motivation behind #506 (env-driven secrets in compose) without touching the TOML loader.

Diff is 3 lines: flag definition + assignment to `conf.ProxyProtocolListener.Value`. `go vet ./...` and `go build ./...` clean; `mtg simple-run --help` shows the flag.