### PR TITLE
contrib/sni-router: fix bogus 2.4 version reference

### DIFF
--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -89,8 +89,9 @@ service (Caddy), bypassing HAProxy.  `proxy-protocol = true` matches
 Caddy's `:8443` listener wrapper so the real client IP still
 propagates to Caddy's logs.
 
-Requires mtg ≥ 2.4 — hostname acceptance for the fronting target was
-added in #480.
+Requires the hostname-acceptance change from #480 (merged 2026-05-05).
+No tagged release contains it yet — build from master until the next
+mtg release ships.
 
 ## ACME (Let's Encrypt) notes
 


### PR DESCRIPTION
The `contrib/sni-router/README.md` line that said *"Requires mtg ≥ 2.4"* (added in 0fdf6cb, my mistake) points at a release that doesn't exist — the latest tag is `v2.2.8` from 2026-04-07, and #480 is in master since 2026-05-05 but not yet in any tagged release.

Replaces it with an honest reference to #480 plus a "build from master until the next release ships" note, which stays correct regardless of when the next tag actually lands.

Refs #511.