### PR TITLE
docs: mark secret as (required) in example.config.toml

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -15,9 +15,9 @@
 # you have any issue.
 debug = true
 
-# A secret. Please remember that mtg supports only FakeTLS mode, legacy
-# simple and secured mode are prohibited. For you it means that secret
-# should either be base64-encoded or starts with ee.
+# A secret (required). Please remember that mtg supports only FakeTLS
+# mode, legacy simple and secured mode are prohibited. For you it means
+# that secret should either be base64-encoded or starts with ee.
 secret = "ee367a189aee18fa31c190054efd4a8e9573746f726167652e676f6f676c65617069732e636f6d"
 
 # Host:port pair to run proxy on (required).


### PR DESCRIPTION
## Summary

Follow-up to #503 (which introduced `(required)` on `bind-to`). `secret` is the other top-level option without a sensible default, so it takes the same marker, on the first line of its description.

Symmetric with #504 (which introduced `(default)` on `prefer-ipv6`).

## Diff

```diff
-# A secret. Please remember that mtg supports only FakeTLS mode, legacy
-# simple and secured mode are prohibited. For you it means that secret
-# should either be base64-encoded or starts with ee.
+# A secret (required). Please remember that mtg supports only FakeTLS
+# mode, legacy simple and secured mode are prohibited. For you it means
+# that secret should either be base64-encoded or starts with ee.
```

Docs-only, no behavior change.

## Scope note

Deliberately narrow: one option, one marker. Rolling the same convention out to the rest of `example.config.toml` (free-text "default value is X" lines, number-valued defaults, multi-variant enums) involves enough editorial calls that it's better as separate PRs once this and the `bind-to`/`prefer-ipv6` markers have settled.

Per https://github.com/9seconds/mtg/pull/503#discussion_r3237080887.