### PR TITLE
sni-router: host-net HAProxy to preserve real client IPs

### DIFF
--- a/contrib/sni-router/Caddyfile
+++ b/contrib/sni-router/Caddyfile
@@ -10,14 +10,16 @@
 	# to Caddy's access log.  The `tls` wrapper must follow so that TLS
 	# is terminated on the unwrapped connection.
 	#
-	# `allow` lists the networks permitted to send PROXY headers.  These
-	# ranges cover docker compose's default bridge networks; tighten
-	# them if you pin a specific subnet in docker-compose.yml.
+	# `allow` lists the networks permitted to send PROXY headers.
+	# 127.0.0.0/8 covers HAProxy reaching Caddy over host loopback (HAProxy
+	# runs in network_mode: host and connects to the published 127.0.0.1
+	# port).  The RFC1918 ranges cover mtg → Caddy on the compose bridge
+	# (fronting path; see "Fronting loop" in README.md).
 	servers :8443 {
 		listener_wrappers {
 			proxy_protocol {
 				timeout 5s
-				allow 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+				allow 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
 			}
 			tls
 		}

--- a/contrib/sni-router/Caddyfile
+++ b/contrib/sni-router/Caddyfile
@@ -11,7 +11,7 @@
 	# is terminated on the unwrapped connection.
 	#
 	# `allow` lists the networks permitted to send PROXY headers.
-	# 127.0.0.0/8 covers HAProxy reaching Caddy over host loopback (HAProxy
+	# 127.0.0.1/32 covers HAProxy reaching Caddy over host loopback (HAProxy
 	# runs in network_mode: host and connects to the published 127.0.0.1
 	# port).  The RFC1918 ranges cover mtg → Caddy on the compose bridge
 	# (fronting path; see "Fronting loop" in README.md).
@@ -19,7 +19,7 @@
 		listener_wrappers {
 			proxy_protocol {
 				timeout 5s
-				allow 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+				allow 127.0.0.1/32 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
 			}
 			tls
 		}

--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -63,6 +63,26 @@ must stay in sync:
 If you disable one, disable all four, otherwise the backend will fail
 to parse the connection.
 
+### Why HAProxy uses `network_mode: host`
+
+When a container is on a bridge network and a port is published with
+`ports: "443:443"`, the source IP of inbound connections is rewritten
+to the bridge gateway before HAProxy sees it — Docker's `docker-proxy`
+userland forwarder accepts on the host and re-opens the connection
+from the gateway; Podman's `slirp4netns` / `pasta` does the same in
+rootless mode.  The PROXY v2 header HAProxy then sends downstream
+carries that gateway address (e.g. `172.x.x.1`), not the real client.
+
+`network_mode: host` puts HAProxy in the host network namespace, so it
+binds `:443` / `:80` directly with no NAT in the path and observes the
+true source address of every connection.  mtg and Caddy stay on the
+compose bridge and are published only on `127.0.0.1` — HAProxy reaches
+them via host loopback, and the PROXY v2 header carries the real
+client IP (v4 or v6) end-to-end.
+
+Trade-off: HAProxy occupies the host's `:443` and `:80`.  Don't run
+anything else on those ports on the same host.
+
 ## Fronting loop (why `[domain-fronting]` is set explicitly)
 
 When mtg sees TLS that isn't valid Telegram (a probe or a browser

--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -65,23 +65,26 @@ to parse the connection.
 
 ### Why HAProxy uses `network_mode: host`
 
-When a container is on a bridge network and a port is published with
-`ports: "443:443"`, the source IP of inbound connections is rewritten
-to the bridge gateway before HAProxy sees it — Docker's `docker-proxy`
-userland forwarder accepts on the host and re-opens the connection
-from the gateway; Podman's `slirp4netns` / `pasta` does the same in
-rootless mode.  The PROXY v2 header HAProxy then sends downstream
-carries that gateway address (e.g. `172.x.x.1`), not the real client.
+A published port on a bridge network rewrites the source IP of inbound
+connections to the bridge gateway before HAProxy sees it (Docker's
+`docker-proxy`, Podman's `slirp4netns`/`pasta`), so the PROXY v2 header
+HAProxy forwards downstream carries that gateway address, not the real
+client.  Host-mode HAProxy binds in the host netns directly, no NAT in
+the path, and the rewrite never happens.  mtg and Caddy stay on the
+compose bridge and are published on `127.0.0.1` only — HAProxy reaches
+them over host loopback.  `mtg-config.toml` does not need to change;
+fronting still uses `host = "web"` over compose-network DNS.
 
-`network_mode: host` puts HAProxy in the host network namespace, so it
-binds `:443` / `:80` directly with no NAT in the path and observes the
-true source address of every connection.  mtg and Caddy stay on the
-compose bridge and are published only on `127.0.0.1` — HAProxy reaches
-them via host loopback, and the PROXY v2 header carries the real
-client IP (v4 or v6) end-to-end.
-
-Trade-off: HAProxy occupies the host's `:443` and `:80`.  Don't run
-anything else on those ports on the same host.
+**Trade-offs.**
+- HAProxy owns the host's `:443` and `:80` — don't run anything else
+  on those ports.
+- Linux host only.  On Docker Desktop (macOS/Windows), "host" means
+  the Linux VM, not the user's machine, so external clients can't
+  reach the proxy.
+- If you run Docker with `userns-remap`, the in-container "root"
+  loses the privilege to bind `<1024` on the host; either disable
+  `userns-remap` for this stack or lower `net.ipv4.ip_unprivileged_port_start`
+  on the host.
 
 ## Fronting loop (why `[domain-fronting]` is set explicitly)
 

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -27,9 +27,16 @@ x-domain-env: &domain-env
 services:
   haproxy:
     image: haproxy:lts-alpine
-    ports:
-      - "443:443"
-      - "80:80"
+    # network_mode: host lets HAProxy see real client source IPs (v4 and v6)
+    # instead of the docker/podman bridge gateway.  Bridge ingress (docker-proxy
+    # userland forwarder, podman slirp4netns/pasta) rewrites the source address
+    # of inbound connections to the gateway; with host networking HAProxy binds
+    # in the host netns directly and the rewrite never happens.  See the
+    # "Real client IPs" section of README.md.
+    #
+    # Trade-off: HAProxy occupies host :443 and :80.  Don't run anything else
+    # on those ports.
+    network_mode: host
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
     environment:
@@ -38,16 +45,16 @@ services:
       - mtg
       - web
     restart: unless-stopped
-    sysctls:
-      - net.ipv4.ip_unprivileged_port_start=80
 
   mtg:
     # FIXME: :master until #480 lands in a tagged release; switch back to :2/:3 after release
     image: nineseconds/mtg:master
     volumes:
       - ./mtg-config.toml:/config/config.toml:ro,Z
-    expose:
-      - "3128"
+    # Published on host loopback only — HAProxy (host netns) reaches it via
+    # 127.0.0.1:3128.  Not exposed on any public interface.
+    ports:
+      - "127.0.0.1:3128:3128"
     restart: unless-stopped
     extra_hosts:
       - "host.containers.internal:host-gateway"
@@ -58,9 +65,10 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro,Z
       - caddy_data:/data
       - ./www:/srv:ro,Z
-    expose:
-      - "80"
-      - "8443"
+    # Published on host loopback only — HAProxy reaches Caddy on 127.0.0.1.
+    ports:
+      - "127.0.0.1:8080:80"
+      - "127.0.0.1:8443:8443"
     environment:
       <<: *domain-env
     restart: unless-stopped

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -27,15 +27,9 @@ x-domain-env: &domain-env
 services:
   haproxy:
     image: haproxy:lts-alpine
-    # network_mode: host lets HAProxy see real client source IPs (v4 and v6)
-    # instead of the docker/podman bridge gateway.  Bridge ingress (docker-proxy
-    # userland forwarder, podman slirp4netns/pasta) rewrites the source address
-    # of inbound connections to the gateway; with host networking HAProxy binds
-    # in the host netns directly and the rewrite never happens.  See the
-    # "Real client IPs" section of README.md.
-    #
-    # Trade-off: HAProxy occupies host :443 and :80.  Don't run anything else
-    # on those ports.
+    # Host netns so HAProxy sees real client IPs (v4/v6) instead of the
+    # bridge gateway address.  Linux host only; see README → "Why HAProxy
+    # uses network_mode: host" for the rationale and trade-off.
     network_mode: host
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro,Z
@@ -52,7 +46,7 @@ services:
     volumes:
       - ./mtg-config.toml:/config/config.toml:ro,Z
     # Published on host loopback only — HAProxy (host netns) reaches it via
-    # 127.0.0.1:3128.  Not exposed on any public interface.
+    # 127.0.0.1.
     ports:
       - "127.0.0.1:3128:3128"
     restart: unless-stopped
@@ -66,6 +60,7 @@ services:
       - caddy_data:/data
       - ./www:/srv:ro,Z
     # Published on host loopback only — HAProxy reaches Caddy on 127.0.0.1.
+    # Port 8080 (not 80) on the host because HAProxy already owns host :80.
     ports:
       - "127.0.0.1:8080:80"
       - "127.0.0.1:8443:8443"

--- a/contrib/sni-router/haproxy.cfg
+++ b/contrib/sni-router/haproxy.cfg
@@ -23,7 +23,11 @@ defaults
 # --- HTTP :80 — ACME challenges + redirect -----------------------------------
 
 frontend http
-    bind *:80
+    # Explicit v4 + v6 binds so IPv6 clients are accepted regardless of the
+    # host's IPV6_V6ONLY sysctl.  v6only on the v6 bind avoids the
+    # "address in use" overlap on dual-stack hosts.
+    bind 0.0.0.0:80
+    bind [::]:80 v6only
     mode http
 
     # Let Caddy answer ACME HTTP-01 challenges for Let's Encrypt.
@@ -35,7 +39,8 @@ frontend http
 # --- TLS :443 — SNI-based routing -------------------------------------------
 
 frontend tls
-    bind *:443
+    bind 0.0.0.0:443
+    bind [::]:443 v6only
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
 
@@ -46,18 +51,23 @@ frontend tls
 
     default_backend web
 
+# Backends reach mtg and web on host loopback — they publish to 127.0.0.1
+# (see docker-compose.yml), and HAProxy runs in the host netns
+# (network_mode: host).  PROXY v2 still carries the real client address
+# (v4 or v6) end-to-end, independent of the loopback transport.
+
 backend mtg
     # send-proxy-v2 prepends a PROXY protocol v2 header so mtg sees the
     # real client IP instead of HAProxy's.  mtg must have
     # `proxy-protocol-listener = true` in its config.
-    server mtg mtg:3128 send-proxy-v2
+    server mtg 127.0.0.1:3128 send-proxy-v2
 
 backend web
     # send-proxy-v2 prepends a PROXY protocol v2 header so Caddy logs the
     # real client IP instead of HAProxy's.  Caddy must enable the
     # proxy_protocol listener wrapper on :8443 (see Caddyfile).
-    server web web:8443 send-proxy-v2
+    server web 127.0.0.1:8443 send-proxy-v2
 
 backend web_acme
     mode http
-    server web web:80
+    server web 127.0.0.1:8080

--- a/contrib/sni-router/haproxy.cfg
+++ b/contrib/sni-router/haproxy.cfg
@@ -23,12 +23,9 @@ defaults
 # --- HTTP :80 — ACME challenges + redirect -----------------------------------
 
 frontend http
-    # Explicit v4 + v6 binds so IPv6 clients are accepted regardless of the
-    # host's net.ipv6.bindv6only sysctl.  `v6only` on the v6 bind prevents it
-    # from also accepting v4-mapped connections, which would otherwise
-    # conflict with the explicit v4 bind on the same port.
-    bind 0.0.0.0:80
-    bind [::]:80 v6only
+    # Explicit v4 + v6 binds so IPv6 clients are accepted regardless of
+    # the host's net.ipv6.bindv6only sysctl.
+    bind :80,[::]:80
     mode http
 
     # Let Caddy answer ACME HTTP-01 challenges for Let's Encrypt.
@@ -40,8 +37,7 @@ frontend http
 # --- TLS :443 — SNI-based routing -------------------------------------------
 
 frontend tls
-    bind 0.0.0.0:443
-    bind [::]:443 v6only
+    bind :443,[::]:443
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
 

--- a/contrib/sni-router/haproxy.cfg
+++ b/contrib/sni-router/haproxy.cfg
@@ -24,8 +24,9 @@ defaults
 
 frontend http
     # Explicit v4 + v6 binds so IPv6 clients are accepted regardless of the
-    # host's IPV6_V6ONLY sysctl.  v6only on the v6 bind avoids the
-    # "address in use" overlap on dual-stack hosts.
+    # host's net.ipv6.bindv6only sysctl.  `v6only` on the v6 bind prevents it
+    # from also accepting v4-mapped connections, which would otherwise
+    # conflict with the explicit v4 bind on the same port.
     bind 0.0.0.0:80
     bind [::]:80 v6only
     mode http


### PR DESCRIPTION
Follow-up to discussion in #498 — bam80 reported that real client IPs never made it through `contrib/sni-router` despite all four PROXY-protocol pieces being wired up correctly.

## Root cause

When the HAProxy container is on a bridge network and `:443` / `:80` are published via `ports:`, the source IP of every inbound connection is rewritten to the bridge gateway **before** HAProxy sees it:

- Docker (default): `docker-proxy` accepts on the host and re-opens the connection from the bridge gateway.
- Docker with `userland-proxy: false`: kernel DNAT *should* preserve the source, but on Docker 29 / Fedora the MASQUERADE rewrite ([moby/moby#48854](https://github.com/moby/moby/pull/48854)) intermittently drops or rewrites traffic.
- Podman rootless: `slirp4netns` / `pasta` userspace forwarder, no equivalent flag.

In every case HAProxy stamps the gateway address (e.g. `172.x.x.1`) into the PROXY v2 header, so mtg and Caddy faithfully log the wrong IP. The fix has to lift HAProxy out of the rewrite path — no amount of backend-side configuration can recover what HAProxy never received.

## Change

- **HAProxy → `network_mode: host`.** Binds `:443`/`:80` in the host netns directly. No NAT, no userspace forwarder, no source rewrite. Real client IPs (v4 and v6) propagate end-to-end via PROXY v2.
- **mtg and Caddy stay on the compose bridge**, published on `127.0.0.1` only (`127.0.0.1:3128:3128`, `127.0.0.1:8080:80`, `127.0.0.1:8443:8443`). HAProxy reaches them via host loopback.
- **HAProxy frontends gain explicit IPv6 binds** (`bind :443,[::]:443` / `bind :80,[::]:80`). `bind *:443` is IPv4-only; the old example accepted IPv6 only on hosts where dual-stack quirks happened to cover for it.
- **Caddy allow-list gains `127.0.0.1/32`** to cover the new loopback hop from HAProxy. The RFC1918 ranges stay for the fronting path (mtg → Caddy on the compose bridge).
- **README** gains a short subsection explaining the host-mode choice and its trade-offs.

`mtg-config.toml` is intentionally unchanged — mtg and Caddy are still on the compose bridge, so fronting can keep `host = "web"` and resolve over compose-network DNS.

## Alternatives considered

- **`{"userland-proxy": false}` in `/etc/docker/daemon.json`.** Smaller change (host config, no compose edits) but: (a) requires host-level daemon config that the contrib example can't ship, (b) flaky on Docker 29 (MASQUERADE rewrite), (c) doesn't help Podman rootless at all.
- **All three services in `network_mode: host`.** Cleaner network model but requires changing `mtg-config.toml` (fronting `host` and listen address) and loses compose-network isolation. Bigger change for no functional gain over the current layout.

## Trade-offs / platform notes

- HAProxy owns the host's `:443` and `:80`. Don't run anything else on those ports on the same host.
- **Linux host only.** On Docker Desktop (macOS/Windows), `network_mode: host` binds inside the Linux VM, so external clients can't reach the proxy. Out of scope for this contrib example, which is server-deployment-oriented anyway.
- With Docker `userns-remap`, the in-container "root" loses the privilege to bind `<1024`. README documents the workaround.

## Test status

End-to-end validated by @bam80 on Fedora + Docker 29 — both the original revision (real client IPv4/IPv6 visible in mtg and Caddy logs) and the current revision (`DOMAIN=localhost` run after the review-fixups, see [thread](https://github.com/9seconds/mtg/pull/522#discussion_r3270292376)).

Branch rebased on master after the 2026-05-20 batch — picks up #514 (image bump to `:master`, hard dep so the stack actually exposes `proxy-protocol-listener` end-to-end) and #525 (`mtg-config.toml` rendered from tracked `.example`). A fresh checkout now brings up a working stack without manual patching.

Closes #498.
