### PR TITLE
contrib/sni-router: document OpenWrt + podman-compose network workaround

### DIFF
--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -114,6 +114,28 @@ domain's DNS A/AAAA record points to this server before starting.
            └─────────┘  └─────────┘
 ```
 
+## OpenWrt + podman-compose
+
+OpenWrt's firewall zones are bound to interface *names*.  With bare
+`podman` you pin the static `podman0` bridge into a zone and you're
+done — but `podman-compose up` creates a project-scoped network, and
+netavark spawns a *new* bridge for it (`podman1`, `podman2`, …) that
+has no firewall rules, so containers lose outbound access.
+
+Reuse the pre-configured `podman0` by adding to this compose file:
+
+```yaml
+networks:
+  default:
+    external: true
+    name: podman
+```
+
+That tells compose to attach to the router-managed network instead of
+spinning up a new one.  Background:
+[discussion #513](https://github.com/9seconds/mtg/discussions/513)
+and the [OpenWrt forum thread](https://forum.openwrt.org/t/podman-compose-dontt-have-network-access/250230).
+
 ## Files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

Documents a footgun spotted via discussion #513: when the `contrib/sni-router` stack is deployed on OpenWrt with `podman-compose`, containers lose outbound network access.

Root cause: `podman-compose up` creates a project-scoped network, and netavark spawns a fresh bridge (`podman1`, `podman2`, …) for it that has no firewall rules — OpenWrt zones are bound to interface names and only know about the static `podman0` from `/etc/init.d/podman`.

The fix is a one-liner the user adds to their local `docker-compose.yml`:

```yaml
networks:
  default:
    external: true
    name: podman
```

This PR just adds a short "OpenWrt + podman-compose" section to the sni-router README explaining this, with links to the discussion and the OpenWrt forum thread where two solutions were vetted. Doc-only; no code, no compose-file change (Docker users see no diff).

## Background

- #513
- https://forum.openwrt.org/t/podman-compose-dontt-have-network-access/250230

## Notes

- Picked `external: true` form over plain `name: podman` because the router-managed `podman0` may have IPAM/driver settings that don't match what compose would otherwise try to assert, leading to *"network already exists with different settings"*. `external: true` makes "do not touch this network" explicit.
- No changes to the shipped `docker-compose.yml` — it stays portable for Docker users; the README points OpenWrt users at the local override they need.