### PR TITLE
contrib/sni-router: render mtg-config.toml from a tracked .example

### DIFF
--- a/contrib/sni-router/.gitignore
+++ b/contrib/sni-router/.gitignore
@@ -1,0 +1,5 @@
+# Rendered from mtg-config.toml.example; contains the live secret.
+mtg-config.toml
+
+# Local environment overrides (DOMAIN, MTG_SECRET, ...)
+.env

--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -31,7 +31,8 @@ docker run --rm nineseconds/mtg:2 generate-secret --hex YOUR_DOMAIN
 #    - .env (or export)  →  DOMAIN=your.domain   # used by HAProxy + Caddy
 #    - render mtg-config.toml from the tracked template
 #      (the rendered file is gitignored — secret stays out of git):
-MTG_SECRET=<secret-from-step-2> envsubst < mtg-config.toml.example > mtg-config.toml
+export MTG_SECRET=...    # paste the hex secret from step 2
+envsubst < mtg-config.toml.example > mtg-config.toml
 #      (Or `cp mtg-config.toml.example mtg-config.toml` and edit ${MTG_SECRET}
 #      by hand if you don't have envsubst.)
 

--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -29,7 +29,11 @@ docker run --rm nineseconds/mtg:2 generate-secret --hex YOUR_DOMAIN
 
 # 3. Configure:
 #    - .env (or export)  →  DOMAIN=your.domain   # used by HAProxy + Caddy
-#    - mtg-config.toml   →  paste the secret
+#    - render mtg-config.toml from the tracked template
+#      (the rendered file is gitignored — secret stays out of git):
+MTG_SECRET=<secret-from-step-2> envsubst < mtg-config.toml.example > mtg-config.toml
+#      (Or `cp mtg-config.toml.example mtg-config.toml` and edit ${MTG_SECRET}
+#      by hand if you don't have envsubst.)
 
 # 4. (Optional) put your site content into www/
 
@@ -120,6 +124,7 @@ domain's DNS A/AAAA record points to this server before starting.
 |---|---|
 | `docker-compose.yml` | Service definitions |
 | `haproxy.cfg` | SNI routing rules (reads `$DOMAIN` from the environment) |
-| `mtg-config.toml` | mtg proxy config — **paste your secret** |
+| `mtg-config.toml.example` | mtg proxy config template — render with `envsubst` or copy + edit |
+| `mtg-config.toml` | Rendered mtg proxy config (gitignored, contains your secret) |
 | `Caddyfile` | Web server config (auto-HTTPS) |
 | `www/` | Static site content served by Caddy |

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -11,7 +11,8 @@
 # Quick start:
 #   1. Set DOMAIN in a .env file next to this one (or export it)
 #   2. mtg generate-secret YOUR_DOMAIN   -> render mtg-config.toml:
-#        MTG_SECRET=<secret> envsubst < mtg-config.toml.example > mtg-config.toml
+#        export MTG_SECRET=...     # paste the hex secret
+#        envsubst < mtg-config.toml.example > mtg-config.toml
 #      (the rendered file is gitignored). See README.md for the cp+edit variant.
 #   3. docker compose up -d
 #

--- a/contrib/sni-router/docker-compose.yml
+++ b/contrib/sni-router/docker-compose.yml
@@ -10,7 +10,9 @@
 #
 # Quick start:
 #   1. Set DOMAIN in a .env file next to this one (or export it)
-#   2. mtg generate-secret YOUR_DOMAIN   -> paste into mtg-config.toml
+#   2. mtg generate-secret YOUR_DOMAIN   -> render mtg-config.toml:
+#        MTG_SECRET=<secret> envsubst < mtg-config.toml.example > mtg-config.toml
+#      (the rendered file is gitignored). See README.md for the cp+edit variant.
 #   3. docker compose up -d
 #
 # DOMAIN is forwarded to both Caddy (TLS cert) and HAProxy (SNI ACL),

--- a/contrib/sni-router/mtg-config.toml.example
+++ b/contrib/sni-router/mtg-config.toml.example
@@ -1,10 +1,16 @@
-# Minimal mtg configuration for the SNI-router setup.
+# Minimal mtg configuration template for the SNI-router setup.
 #
-# 1. Generate a secret:  mtg generate-secret --hex <your.domain>
-# 2. Paste it into the `secret` field below.
-# 3. Set DOMAIN=<your.domain> in .env (HAProxy + Caddy pick it up).
+# This is the tracked template; `docker compose` mounts `mtg-config.toml`
+# (gitignored), so render or copy this file before `docker compose up -d`:
+#
+#   1. Set DOMAIN=<your.domain> in .env (HAProxy + Caddy pick it up).
+#   2. Generate the secret:  mtg generate-secret --hex <your.domain>
+#   3. Produce mtg-config.toml — pick one:
+#        MTG_SECRET=<secret> envsubst < mtg-config.toml.example > mtg-config.toml
+#      or just copy and hand-edit `${MTG_SECRET}`:
+#        cp mtg-config.toml.example mtg-config.toml && $EDITOR mtg-config.toml
 
-secret = "PASTE_YOUR_SECRET_HERE"
+secret = "${MTG_SECRET}"
 bind-to = "[::]:3128"
 
 # HAProxy in front sends PROXY protocol v2 headers so mtg can see the

--- a/contrib/sni-router/mtg-config.toml.example
+++ b/contrib/sni-router/mtg-config.toml.example
@@ -6,7 +6,8 @@
 #   1. Set DOMAIN=<your.domain> in .env (HAProxy + Caddy pick it up).
 #   2. Generate the secret:  mtg generate-secret --hex <your.domain>
 #   3. Produce mtg-config.toml — pick one:
-#        MTG_SECRET=<secret> envsubst < mtg-config.toml.example > mtg-config.toml
+#        export MTG_SECRET=...     # paste the hex secret
+#        envsubst < mtg-config.toml.example > mtg-config.toml
 #      or just copy and hand-edit `${MTG_SECRET}`:
 #        cp mtg-config.toml.example mtg-config.toml && $EDITOR mtg-config.toml
 


### PR DESCRIPTION
## Summary

Track `mtg-config.toml.example` with `secret = "${MTG_SECRET}"`; the rendered `mtg-config.toml` (and `.env`) are now gitignored. The secret never lands in a tracked file, which is the gap discussed in #506.

Quick start step 3 switches from:

> `mtg-config.toml` → paste the secret

to either:

```bash
export MTG_SECRET=...    # paste the hex secret from step 2
envsubst < mtg-config.toml.example > mtg-config.toml
```

or, for users without `envsubst`:

```bash
cp mtg-config.toml.example mtg-config.toml && $EDITOR mtg-config.toml   # edit ${MTG_SECRET}
```

Single placeholder file works for either workflow.

## Why this shape

#506 asked for env-var support inside the TOML loader; @9seconds settled that with "TOML stays static, templating belongs in deploy-layer CLI tools" (composability). That principle leaves the contrib example as the right place to *show* the standard templating step, not mtg itself. This PR does exactly that — keeps mtg static, keeps the compose minimal (no init container, no entrypoint rewrites, no `apk add` at startup), and uses the tool @9seconds named (`envsubst`) as the documented path while still working with a plain `cp` + edit for users on platforms without it.

After #502 made DOMAIN env-driven for HAProxy + Caddy, the secret was the last manual touch of a tracked file in the example. This closes that gap.

## Test plan

- [x] `envsubst < mtg-config.toml.example > mtg-config.toml` produces a valid TOML file with `secret = "<resolved>"`
- [x] No code changes; mtg parses the rendered file exactly as before (only the placeholder line differs from current behaviour)
- [x] `.gitignore` covers both `mtg-config.toml` and `.env`
- [x] README quick start, file table, and docker-compose.yml header comment all updated in sync
- [x] `export MTG_SECRET=... ; envsubst < ...` form is shell-safe on literal copy-paste (the earlier `MTG_SECRET=<placeholder>` form parsed `<placeholder>` as a redirection — fixed in 3d0899d)
