### PR TITLE
sni-router: point single-domain users at the two-service setup

### DIFF
--- a/contrib/sni-router/README.md
+++ b/contrib/sni-router/README.md
@@ -19,6 +19,21 @@ flagged.  With this setup:
 Because your domain's DNS points to this server, the SNI/IP match is
 natural and passive DPI has nothing to flag.
 
+## Do you need HAProxy at all?
+
+For a single domain you can run just two services: mtg itself owns
+`:443` and relays non-Telegram TLS to Caddy through its built-in
+domain fronting — the same job HAProxy does here, decided by secret
+validation instead of SNI.  See
+[Setup Without SNI Router](https://github.com/9seconds/mtg/wiki/Setup-Without-SNI-Router)
+in the wiki for a ready-made compose.
+
+Keep the HAProxy variant when you need either of:
+
+- several domains/backends multiplexed on the same `:443` — mtg has a
+  single fronting target;
+- the website to stay up while mtg is down or restarting.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a short "Do you need HAProxy at all?" section to `contrib/sni-router/README.md`, pointing single-domain users at the new wiki page [Setup Without SNI Router](https://github.com/9seconds/mtg/wiki/Setup-Without-SNI-Router) (mtg on :443 + Caddy, routing via mtg's built-in domain fronting — two services instead of three), and listing the two cases where the HAProxy variant is still the right choice (multi-domain on one :443, site survives mtg downtime).

Prompted by discussion #548.

Docs-only: +17 lines in one README, no config or code changes.