### PR TITLE
Add Linux IPv4 DPI desync mode for FakeTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Flags:
   -n, --doh-ip=1.1.1.1                 IP address of DNS-over-HTTP to use.
   -t, --timeout=10s                    Network timeout to use
   -a, --antireplay-cache-size="1MB"    A size of anti-replay cache to use.
+      --dpi-desync                     Enable Linux IPv4 DPI desync for fake TLS handshakes.
 ```
 
 So, if you want to startup a proxy with CLI only, you can do something like
@@ -401,6 +402,10 @@ bind-to = "0.0.0.0:443"
 This is enough to run the whole application. All other
 options already have sensible defaults for the app at almost any scale.
 
+`dpi-desync = true` enables Linux IPv4-only DPI desync for FakeTLS
+handshakes. It opens a raw packet socket, so run mtg as root or grant
+`CAP_NET_RAW`.
+
 ### Run a proxy
 
 Put a binary and a config into your webserver. Just for example,
@@ -422,6 +427,8 @@ RestartSec=3
 DynamicUser=true
 LimitNOFILE=65536
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+# If dpi-desync = true, also add CAP_NET_RAW:
+# AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
 
 [Install]
 WantedBy=multi-user.target

--- a/essentials/conns.go
+++ b/essentials/conns.go
@@ -1,8 +1,10 @@
 package essentials
 
 import (
+	"fmt"
 	"io"
 	"net"
+	"syscall"
 )
 
 // CloseableReader is an [io.Reader] interface that can close its reading end.
@@ -48,4 +50,18 @@ func (n netConnWrapper) CloseWrite() error {
 // WrapConn wraps a generic [net.Conn] into Conn.
 func WrapNetConn(conn net.Conn) Conn {
 	return netConnWrapper{conn}
+}
+
+func SetTCPWindowClamp(conn net.Conn, value int) error {
+	sysConn, ok := conn.(syscall.Conn)
+	if !ok {
+		return nil
+	}
+
+	rawConn, err := sysConn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("cannot get raw connection: %w", err)
+	}
+
+	return SetRawTCPWindowClamp(rawConn, value)
 }

--- a/essentials/tcp_options_linux.go
+++ b/essentials/tcp_options_linux.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package essentials
+
+import (
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func SetRawTCPWindowClamp(conn syscall.RawConn, value int) error {
+	var err error
+
+	if controlErr := conn.Control(func(fd uintptr) {
+		err = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_WINDOW_CLAMP, value)
+	}); controlErr != nil && err == nil {
+		return fmt.Errorf("cannot access TCP socket: %w", controlErr)
+	}
+	if err != nil {
+		return fmt.Errorf("cannot set TCP_WINDOW_CLAMP: %w", err)
+	}
+
+	return nil
+}

--- a/essentials/tcp_options_other.go
+++ b/essentials/tcp_options_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package essentials
+
+import "syscall"
+
+func SetRawTCPWindowClamp(_ syscall.RawConn, _ int) error {
+	return nil
+}

--- a/example.config.toml
+++ b/example.config.toml
@@ -37,6 +37,12 @@ bind-to = "0.0.0.0:3128"
 # default value is false.
 # proxy-protocol-listener = false
 
+# Enable Linux IPv4 DPI desync for FakeTLS handshakes. This opens a raw packet
+# socket, so the process needs root or CAP_NET_RAW. The option is ignored on
+# non-Linux builds.
+# default value is false.
+# dpi-desync = false
+
 # Defines how many concurrent connections are allowed to this proxy.
 # All other incoming connections are going to be dropped.
 concurrency = 8192

--- a/internal/cli/run_proxy.go
+++ b/internal/cli/run_proxy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/9seconds/mtg/v2/antireplay"
 	"github.com/9seconds/mtg/v2/events"
 	"github.com/9seconds/mtg/v2/internal/config"
+	"github.com/9seconds/mtg/v2/internal/desync"
 	"github.com/9seconds/mtg/v2/internal/proxyprotocol"
 	"github.com/9seconds/mtg/v2/internal/utils"
 	"github.com/9seconds/mtg/v2/ipblocklist"
@@ -179,7 +180,8 @@ func makeEventStream(conf *config.Config, logger mtglib.Logger) (mtglib.EventStr
 			conf.Stats.StatsD.Address.Get(""),
 			logger.Named("statsd"),
 			conf.Stats.StatsD.MetricPrefix.Get(stats.DefaultStatsdMetricPrefix),
-			conf.Stats.StatsD.TagFormat.Get(stats.DefaultStatsdTagFormat))
+			conf.Stats.StatsD.TagFormat.Get(stats.DefaultStatsdTagFormat),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot build statsd observer: %w", err)
 		}
@@ -254,6 +256,8 @@ func warnDeprecatedDomainFronting(conf *config.Config, log mtglib.Logger) {
 	}
 }
 
+const dpiDesyncHandshakeWindowClamp = 256
+
 func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyclop
 	logger := makeLogger(conf)
 
@@ -279,7 +283,8 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 		ntw,
 		func(ctx context.Context, size int) {
 			eventStream.Send(ctx, mtglib.NewEventIPListSize(size, true))
-		})
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("cannot build ip blocklist: %w", err)
 	}
@@ -294,6 +299,13 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 	)
 	if err != nil {
 		return fmt.Errorf("cannot build ip allowlist: %w", err)
+	}
+
+	windowClamp := 0
+	if conf.DPIDesync.Get(false) {
+		// Empirically chosen: small enough for Linux IPv4 DPI desync, but still
+		// large enough for Telegram media after the post-handshake clamp restore.
+		windowClamp = dpiDesyncHandshakeWindowClamp
 	}
 
 	doppelGangerURLs := make([]string, len(conf.Defense.Doppelganger.URLs))
@@ -326,6 +338,8 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 		DoppelGangerPerRaid: conf.Defense.Doppelganger.Repeats.Get(mtglib.DoppelGangerPerRaid),
 		DoppelGangerEach:    conf.Defense.Doppelganger.UpdateEach.Get(mtglib.DoppelGangerEach),
 		DoppelGangerDRS:     conf.Defense.Doppelganger.DRS.Get(false),
+
+		DPIDesync: windowClamp > 0,
 	}
 
 	proxy, err := mtglib.NewProxy(opts)
@@ -333,7 +347,7 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 		return fmt.Errorf("cannot create a proxy: %w", err)
 	}
 
-	listener, err := utils.NewListener(conf.BindTo.Get(""), 0)
+	listener, err := utils.NewListener(conf.BindTo.Get(""), windowClamp)
 	if err != nil {
 		return fmt.Errorf("cannot start proxy: %w", err)
 	}
@@ -347,6 +361,14 @@ func runProxy(conf *config.Config, version string) error { //nolint: funlen, cyc
 	}
 
 	ctx := utils.RootContext()
+
+	if windowClamp > 0 {
+		desyncSvc, err := desync.Start(int(conf.BindTo.Port))
+		if err != nil {
+			return fmt.Errorf("cannot start raw desync: %w", err)
+		}
+		defer desyncSvc.Close() //nolint: errcheck
+	}
 
 	go proxy.Serve(listener) //nolint: errcheck
 

--- a/internal/cli/simple_run.go
+++ b/internal/cli/simple_run.go
@@ -13,17 +13,19 @@ type SimpleRun struct {
 	BindTo string `kong:"arg,required,name='bind-to',help='A host:port to bind proxy to.'"`
 	Secret string `kong:"arg,required,name='secret',help='Proxy secret.'"`
 
-	Debug               bool          `kong:"name='debug',short='d',help='Run in debug mode.'"`                                                                        //nolint: lll
-	Concurrency         uint64        `kong:"name='concurrency',short='c',default='8192',help='Max number of concurrent connection to proxy.'"`                        //nolint: lll
-	TCPBuffer           string        `kong:"name='tcp-buffer',short='b',default='4KB',help='Deprecated and ignored'"`                                                 //nolint: lll
-	PreferIP            string        `kong:"name='prefer-ip',short='i',default='prefer-ipv6',help='IP preference. By default we prefer IPv6 with fallback to IPv4.'"` //nolint: lll
-	DomainFrontingPort  uint64        `kong:"name='domain-fronting-port',short='p',default='443',help='A port to access for domain fronting.'"`                                                                  //nolint: lll
-	DomainFrontingHost  string        `kong:"name='domain-fronting-host',help='Hostname or IP to dial for domain fronting instead of resolving the secret hostname.'"`                                           //nolint: lll
-	DomainFrontingIP    string        `kong:"name='domain-fronting-ip',help='Deprecated: use --domain-fronting-host. Setting this flag logs a warning at startup and the value is ignored.'"`                    //nolint: lll
-	DOHIP               net.IP        `kong:"name='doh-ip',short='n',default='1.1.1.1',help='IP address of DNS-over-HTTP to use.'"`                                    //nolint: lll
-	Timeout             time.Duration `kong:"name='timeout',short='t',default='10s',help='Network timeout to use'"`                                                    //nolint: lll
-	Socks5Proxies       []string      `kong:"name='socks5-proxy',short='s',help='Socks5 proxies to use for network access.'"`                                          //nolint: lll
-	AntiReplayCacheSize string        `kong:"name='antireplay-cache-size',short='a',default='1MB',help='A size of anti-replay cache to use.'"`                         //nolint: lll
+	Debug               bool          `kong:"name='debug',short='d',help='Run in debug mode.'"`                                                                                               //nolint: lll
+	Concurrency         uint64        `kong:"name='concurrency',short='c',default='8192',help='Max number of concurrent connection to proxy.'"`                                               //nolint: lll
+	TCPBuffer           string        `kong:"name='tcp-buffer',short='b',default='4KB',help='Deprecated and ignored'"`                                                                        //nolint: lll
+	PreferIP            string        `kong:"name='prefer-ip',short='i',default='prefer-ipv6',help='IP preference. By default we prefer IPv6 with fallback to IPv4.'"`                        //nolint: lll
+	DomainFrontingPort  uint64        `kong:"name='domain-fronting-port',short='p',default='443',help='A port to access for domain fronting.'"`                                               //nolint: lll
+	DomainFrontingHost  string        `kong:"name='domain-fronting-host',help='Hostname or IP to dial for domain fronting instead of resolving the secret hostname.'"`                        //nolint: lll
+	DomainFrontingIP    string        `kong:"name='domain-fronting-ip',help='Deprecated: use --domain-fronting-host. Setting this flag logs a warning at startup and the value is ignored.'"` //nolint: lll
+	DOHIP               net.IP        `kong:"name='doh-ip',short='n',default='1.1.1.1',help='IP address of DNS-over-HTTP to use.'"`                                                           //nolint: lll
+	Timeout             time.Duration `kong:"name='timeout',short='t',default='10s',help='Network timeout to use'"`                                                                           //nolint: lll
+	Socks5Proxies       []string      `kong:"name='socks5-proxy',short='s',help='Socks5 proxies to use for network access.'"`                                                                 //nolint: lll
+	AntiReplayCacheSize string        `kong:"name='antireplay-cache-size',short='a',default='1MB',help='A size of anti-replay cache to use.'"`                                                //nolint: lll
+
+	DPIDesync bool `kong:"name='dpi-desync',help='Enable Linux IPv4 DPI desync for fake TLS handshakes.'"` //nolint: lll
 
 	ProxyProtocolListener bool `kong:"name='proxy-protocol-listener',help='Expect PROXY protocol (v1 or v2) headers on the listener. Use when mtg sits behind HAProxy, nginx stream, or similar.'"` //nolint: lll
 }
@@ -99,6 +101,7 @@ func (s *SimpleRun) Run(cli *CLI, version string) error { //nolint: cyclop,funle
 	conf.Debug.Value = s.Debug
 	conf.AllowFallbackOnUnknownDC.Value = true
 	conf.Defense.AntiReplay.Enabled.Value = true
+	conf.DPIDesync.Value = s.DPIDesync
 	conf.ProxyProtocolListener.Value = s.ProxyProtocolListener
 
 	if err := conf.Validate(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Secret                      mtglib.Secret   `json:"secret"`
 	BindTo                      TypeHostPort    `json:"bindTo"`
 	ProxyProtocolListener       TypeBool        `json:"proxyProtocolListener"`
+	DPIDesync                   TypeBool        `json:"dpiDesync"`
 	PreferIP                    TypePreferIP    `json:"preferIp"`
 	AutoUpdate                  TypeBool        `json:"autoUpdate"`
 	DomainFrontingPort          TypePort        `json:"domainFrontingPort"`
@@ -71,10 +72,10 @@ type Config struct {
 			Interval TypeDuration    `json:"interval"`
 			Count    TypeConcurrency `json:"count"`
 		} `json:"keepAlive"`
-		DOHIP            TypeIP         `json:"dohIp"`
-		DNS              TypeDNSURI     `json:"dns"`
-		Proxies          []TypeProxyURL `json:"proxies"`
-		TCPNotSentLowat  TypeBytes      `json:"tcpNotSentLowat"`
+		DOHIP           TypeIP         `json:"dohIp"`
+		DNS             TypeDNSURI     `json:"dns"`
+		Proxies         []TypeProxyURL `json:"proxies"`
+		TCPNotSentLowat TypeBytes      `json:"tcpNotSentLowat"`
 	} `json:"network"`
 	Stats struct {
 		StatsD struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,12 @@ func (suite *ConfigTestSuite) TestParsePublicIPNotSet() {
 	suite.Nil(conf.PublicIPv6.Get(nil))
 }
 
+func (suite *ConfigTestSuite) TestParseDPIDesync() {
+	conf, err := config.Parse(suite.ReadConfig("dpi_desync.toml"))
+	suite.NoError(err)
+	suite.True(conf.DPIDesync.Get(false))
+}
+
 func (suite *ConfigTestSuite) TestString() {
 	conf, err := config.Parse(suite.ReadConfig("minimal.toml"))
 	suite.NoError(err)

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -14,6 +14,7 @@ type tomlConfig struct {
 	Secret                      string `toml:"secret" json:"secret"`
 	BindTo                      string `toml:"bind-to" json:"bindTo"`
 	ProxyProtocolListener       bool   `toml:"proxy-protocol-listener" json:"proxyProtocolListener"`
+	DPIDesync                   bool   `toml:"dpi-desync" json:"dpiDesync,omitempty"`
 	PreferIP                    string `toml:"prefer-ip" json:"preferIp,omitempty"`
 	AutoUpdate                  bool   `toml:"auto-update" json:"autoUpdate,omitempty"`
 	DomainFrontingPort          uint   `toml:"domain-fronting-port" json:"domainFrontingPort,omitempty"`

--- a/internal/config/testdata/dpi_desync.toml
+++ b/internal/config/testdata/dpi_desync.toml
@@ -1,0 +1,3 @@
+secret = "7oe1GqLy6TBc38CV3jx7q09nb29nbGUuY29t"
+bind-to = "0.0.0.0:3128"
+dpi-desync = true

--- a/internal/desync/service_linux.go
+++ b/internal/desync/service_linux.go
@@ -1,0 +1,372 @@
+//go:build linux
+
+package desync
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	tcpFlagFin = 0x01
+	tcpFlagSyn = 0x02
+	tcpFlagPsh = 0x08
+	tcpFlagAck = 0x10
+
+	desyncStateTTL     = 30 * time.Second
+	desyncCleanupEvery = time.Second
+	ethernetHeaderLen  = 14
+	vlanHeaderLen      = 4
+	ipv4HeaderLen      = 20
+	tcpHeaderLen       = 20
+)
+
+var fakeTLSAlert = []byte{0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28}
+
+type runner struct {
+	port      uint16
+	packetFD  int
+	rawFD     int
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	state     map[connKey]*connState
+	ident     uint16
+	cleanup   time.Time
+}
+
+type connKey struct {
+	clientIP   [4]byte
+	localIP    [4]byte
+	clientPort uint16
+}
+
+type connState struct {
+	clientSeq uint32
+	serverSeq uint32
+	expiresAt time.Time
+	sentMask  uint8
+}
+
+type tcpPacket struct {
+	srcIP   [4]byte
+	dstIP   [4]byte
+	srcPort uint16
+	dstPort uint16
+	seq     uint32
+	ack     uint32
+	flags   byte
+}
+
+func Start(port int) (io.Closer, error) {
+	if port <= 0 || port > 65535 {
+		return nil, fmt.Errorf("invalid desync port: %d", port)
+	}
+
+	packetFD, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_CLOEXEC, int(htons(unix.ETH_P_IP)))
+	if err != nil {
+		return nil, fmt.Errorf("cannot open packet socket: %w", err)
+	}
+
+	rawFD, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW|unix.SOCK_CLOEXEC, unix.IPPROTO_RAW)
+	if err != nil {
+		unix.Close(packetFD) //nolint: errcheck
+
+		return nil, fmt.Errorf("cannot open raw ipv4 socket: %w", err)
+	}
+	if err := unix.SetsockoptInt(rawFD, unix.IPPROTO_IP, unix.IP_HDRINCL, 1); err != nil {
+		unix.Close(packetFD) //nolint: errcheck
+		unix.Close(rawFD)    //nolint: errcheck
+
+		return nil, fmt.Errorf("cannot enable IP_HDRINCL: %w", err)
+	}
+
+	r := &runner{
+		port:     uint16(port),
+		packetFD: packetFD,
+		rawFD:    rawFD,
+		state:    map[connKey]*connState{},
+	}
+
+	r.wg.Add(1)
+	go r.loop()
+
+	return r, nil
+}
+
+func (r *runner) Close() error {
+	r.closeOnce.Do(func() {
+		unix.Close(r.packetFD) //nolint: errcheck
+		unix.Close(r.rawFD)    //nolint: errcheck
+		r.wg.Wait()
+	})
+
+	return nil
+}
+
+func (r *runner) loop() {
+	defer r.wg.Done()
+
+	buf := make([]byte, 64*1024)
+	for {
+		n, _, err := unix.Recvfrom(r.packetFD, buf, 0)
+		if err != nil {
+			if err == unix.EBADF || err == unix.EINVAL {
+				return
+			}
+
+			continue
+		}
+
+		packet, ok := parseIPv4TCP(buf[:n])
+		if !ok {
+			continue
+		}
+
+		switch {
+		case packet.dstPort == r.port:
+			r.handleInbound(packet)
+		case packet.srcPort == r.port:
+			r.handleOutbound(packet)
+		}
+	}
+}
+
+func (r *runner) handleInbound(packet tcpPacket) {
+	key := connKey{
+		clientIP:   packet.srcIP,
+		localIP:    packet.dstIP,
+		clientPort: packet.srcPort,
+	}
+
+	now := time.Now()
+
+	r.cleanupExpired(now)
+
+	state := r.state[key]
+	if packet.flags&tcpFlagSyn != 0 && packet.flags&tcpFlagAck == 0 {
+		if state == nil {
+			state = &connState{}
+			r.state[key] = state
+		}
+		state.clientSeq = packet.seq
+		state.expiresAt = now.Add(desyncStateTTL)
+
+		return
+	}
+
+	if state == nil {
+		return
+	}
+
+	state.expiresAt = now.Add(desyncStateTTL)
+
+	if packet.flags&tcpFlagFin != 0 {
+		delete(r.state, key)
+
+		return
+	}
+
+	if packet.flags&tcpFlagAck != 0 &&
+		state.clientSeq != 0 &&
+		state.serverSeq != 0 &&
+		packet.seq == state.clientSeq+1 &&
+		packet.ack == state.serverSeq+1 {
+		r.sendFake(key, state, 1)
+		delete(r.state, key)
+	}
+}
+
+func (r *runner) handleOutbound(packet tcpPacket) {
+	if packet.flags&tcpFlagSyn == 0 || packet.flags&tcpFlagAck == 0 {
+		return
+	}
+
+	key := connKey{
+		clientIP:   packet.dstIP,
+		localIP:    packet.srcIP,
+		clientPort: packet.dstPort,
+	}
+
+	now := time.Now()
+
+	r.cleanupExpired(now)
+
+	state := r.state[key]
+	if state == nil {
+		state = &connState{}
+		r.state[key] = state
+	}
+
+	state.serverSeq = packet.seq
+	state.expiresAt = now.Add(desyncStateTTL)
+
+	if state.clientSeq != 0 {
+		r.sendFake(key, state, 0)
+	}
+}
+
+func (r *runner) sendFake(key connKey, state *connState, phase uint8) {
+	mask := uint8(1) << phase
+	if state.sentMask&mask != 0 {
+		return
+	}
+	state.sentMask |= mask
+	r.ident++
+
+	packet := buildIPv4TCPPacket(key.localIP, key.clientIP,
+		r.port, key.clientPort, state.serverSeq+1, state.clientSeq+1, r.ident)
+
+	unix.Sendto(r.rawFD, packet, 0, &unix.SockaddrInet4{Addr: key.clientIP}) //nolint: errcheck
+}
+
+func (r *runner) cleanupExpired(now time.Time) {
+	if now.Before(r.cleanup) {
+		return
+	}
+	r.cleanup = now.Add(desyncCleanupEvery)
+
+	for key, state := range r.state {
+		if now.After(state.expiresAt) {
+			delete(r.state, key)
+		}
+	}
+}
+
+func parseIPv4TCP(frame []byte) (tcpPacket, bool) {
+	if len(frame) < ethernetHeaderLen {
+		return tcpPacket{}, false
+	}
+
+	etherType := binary.BigEndian.Uint16(frame[12:14])
+	ipOffset := ethernetHeaderLen
+	if etherType == 0x8100 || etherType == 0x88a8 {
+		if len(frame) < ethernetHeaderLen+vlanHeaderLen {
+			return tcpPacket{}, false
+		}
+		etherType = binary.BigEndian.Uint16(frame[16:18])
+		ipOffset += vlanHeaderLen
+	}
+	if etherType != unix.ETH_P_IP {
+		return tcpPacket{}, false
+	}
+	if len(frame) < ipOffset+ipv4HeaderLen {
+		return tcpPacket{}, false
+	}
+
+	ip := frame[ipOffset:]
+	ihl := int(ip[0]&0x0f) * 4
+	if ihl < ipv4HeaderLen || len(ip) < ihl+tcpHeaderLen {
+		return tcpPacket{}, false
+	}
+	if ip[0]>>4 != 4 || ip[9] != unix.IPPROTO_TCP {
+		return tcpPacket{}, false
+	}
+
+	fragment := binary.BigEndian.Uint16(ip[6:8])
+	if fragment&0x1fff != 0 {
+		return tcpPacket{}, false
+	}
+
+	totalLen := int(binary.BigEndian.Uint16(ip[2:4]))
+	if totalLen < ihl+tcpHeaderLen || totalLen > len(ip) {
+		return tcpPacket{}, false
+	}
+
+	tcp := ip[ihl:totalLen]
+	dataOffset := int(tcp[12]>>4) * 4
+	if dataOffset < tcpHeaderLen || len(tcp) < dataOffset {
+		return tcpPacket{}, false
+	}
+
+	var packet tcpPacket
+	copy(packet.srcIP[:], ip[12:16])
+	copy(packet.dstIP[:], ip[16:20])
+	packet.srcPort = binary.BigEndian.Uint16(tcp[0:2])
+	packet.dstPort = binary.BigEndian.Uint16(tcp[2:4])
+	packet.seq = binary.BigEndian.Uint32(tcp[4:8])
+	packet.ack = binary.BigEndian.Uint32(tcp[8:12])
+	packet.flags = tcp[13]
+
+	return packet, true
+}
+
+func buildIPv4TCPPacket(
+	srcIP [4]byte,
+	dstIP [4]byte,
+	srcPort uint16,
+	dstPort uint16,
+	seq uint32,
+	ack uint32,
+	ident uint16,
+) []byte {
+	packet := make([]byte, ipv4HeaderLen+tcpHeaderLen+len(fakeTLSAlert))
+	ip := packet[:ipv4HeaderLen]
+	tcp := packet[ipv4HeaderLen : ipv4HeaderLen+tcpHeaderLen]
+
+	ip[0] = 0x45
+	binary.BigEndian.PutUint16(ip[2:4], uint16(len(packet)))
+	binary.BigEndian.PutUint16(ip[4:6], ident)
+	binary.BigEndian.PutUint16(ip[6:8], 0x4000)
+	ip[8] = 64
+	ip[9] = unix.IPPROTO_TCP
+	copy(ip[12:16], srcIP[:])
+	copy(ip[16:20], dstIP[:])
+	binary.BigEndian.PutUint16(ip[10:12], checksum(ip))
+
+	binary.BigEndian.PutUint16(tcp[0:2], srcPort)
+	binary.BigEndian.PutUint16(tcp[2:4], dstPort)
+	binary.BigEndian.PutUint32(tcp[4:8], seq)
+	binary.BigEndian.PutUint32(tcp[8:12], ack)
+	tcp[12] = 5 << 4
+	tcp[13] = tcpFlagPsh | tcpFlagAck
+	binary.BigEndian.PutUint16(tcp[14:16], 65535)
+	copy(packet[ipv4HeaderLen+tcpHeaderLen:], fakeTLSAlert)
+
+	// The checksum is deliberately invalid: DPI can still inspect the fake TLS
+	// alert, but the client TCP stack should drop it.
+	sum := tcpChecksum(srcIP, dstIP, tcp) ^ 0xffff
+	if sum == 0 {
+		sum = 0xffff
+	}
+	binary.BigEndian.PutUint16(tcp[16:18], sum)
+
+	return packet
+}
+
+func tcpChecksum(srcIP, dstIP [4]byte, tcp []byte) uint16 {
+	pseudo := make([]byte, 12+len(tcp)+len(fakeTLSAlert))
+	copy(pseudo[0:4], srcIP[:])
+	copy(pseudo[4:8], dstIP[:])
+	pseudo[9] = unix.IPPROTO_TCP
+	binary.BigEndian.PutUint16(pseudo[10:12], uint16(len(tcp)+len(fakeTLSAlert)))
+	copy(pseudo[12:], tcp)
+	copy(pseudo[12+len(tcp):], fakeTLSAlert)
+
+	return checksum(pseudo)
+}
+
+func checksum(data []byte) uint16 {
+	var sum uint32
+	for len(data) >= 2 {
+		sum += uint32(binary.BigEndian.Uint16(data[:2]))
+		data = data[2:]
+	}
+	if len(data) == 1 {
+		sum += uint32(data[0]) << 8
+	}
+
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+
+	return ^uint16(sum)
+}
+
+func htons(value uint16) uint16 {
+	return (value << 8) | (value >> 8)
+}

--- a/internal/desync/service_linux_test.go
+++ b/internal/desync/service_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package desync
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestBuildAndParseIPv4TCPPacket(t *testing.T) {
+	src := [4]byte{192, 0, 2, 10}
+	dst := [4]byte{198, 51, 100, 20}
+
+	ipPacket := buildIPv4TCPPacket(src, dst, 12345, 9595, 100, 200, 1)
+
+	require.Len(t, ipPacket, 20+20+len(fakeTLSAlert))
+	require.Equal(t, byte(64), ipPacket[8])
+	require.Equal(t, byte(unix.IPPROTO_TCP), ipPacket[9])
+	require.Equal(t, uint16(12345), binary.BigEndian.Uint16(ipPacket[20:22]))
+	require.Equal(t, uint16(9595), binary.BigEndian.Uint16(ipPacket[22:24]))
+	require.Equal(t, uint32(100), binary.BigEndian.Uint32(ipPacket[24:28]))
+	require.Equal(t, uint32(200), binary.BigEndian.Uint32(ipPacket[28:32]))
+	require.Equal(t, byte(tcpFlagPsh|tcpFlagAck), ipPacket[33])
+
+	wireSum := binary.BigEndian.Uint16(ipPacket[36:38])
+	tcp := append([]byte(nil), ipPacket[20:40]...)
+	binary.BigEndian.PutUint16(tcp[16:18], 0)
+	validSum := tcpChecksum(src, dst, tcp)
+	require.Equal(t, validSum^0xffff, wireSum)
+
+	frame := make([]byte, 14+len(ipPacket))
+	binary.BigEndian.PutUint16(frame[12:14], unix.ETH_P_IP)
+	copy(frame[14:], ipPacket)
+
+	packet, ok := parseIPv4TCP(frame)
+
+	require.True(t, ok)
+	require.Equal(t, [4]byte{192, 0, 2, 10}, packet.srcIP)
+	require.Equal(t, [4]byte{198, 51, 100, 20}, packet.dstIP)
+	require.Equal(t, uint16(12345), packet.srcPort)
+	require.Equal(t, uint16(9595), packet.dstPort)
+	require.Equal(t, uint32(100), packet.seq)
+	require.Equal(t, uint32(200), packet.ack)
+	require.Equal(t, byte(tcpFlagPsh|tcpFlagAck), packet.flags)
+}

--- a/internal/desync/service_other.go
+++ b/internal/desync/service_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package desync
+
+import (
+	"errors"
+	"io"
+)
+
+func Start(_ int) (io.Closer, error) {
+	return nil, errors.New("raw TCP desync is supported only on linux")
+}

--- a/internal/proxyprotocol/conn.go
+++ b/internal/proxyprotocol/conn.go
@@ -1,6 +1,11 @@
 package proxyprotocol
 
-import "github.com/pires/go-proxyproto"
+import (
+	"errors"
+	"syscall"
+
+	"github.com/pires/go-proxyproto"
+)
 
 type connWrapper struct {
 	*proxyproto.Conn
@@ -22,4 +27,13 @@ func (c connWrapper) CloseWrite() error {
 	}
 
 	return tcpConn.CloseWrite()
+}
+
+func (c connWrapper) SyscallConn() (syscall.RawConn, error) {
+	tcpConn, ok := c.TCPConn()
+	if !ok {
+		return nil, errors.New("proxy protocol connection is not TCP")
+	}
+
+	return tcpConn.SyscallConn()
 }

--- a/internal/proxyprotocol/conn_test.go
+++ b/internal/proxyprotocol/conn_test.go
@@ -1,0 +1,48 @@
+package proxyprotocol
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnWrapperSyscallConn(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close() //nolint: errcheck
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+
+			return
+		}
+		accepted <- conn
+	}()
+
+	clientConn, err := net.Dial("tcp4", listener.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close() //nolint: errcheck
+
+	var conn net.Conn
+	select {
+	case err := <-acceptErr:
+		require.NoError(t, err)
+	case conn = <-accepted:
+	}
+	defer conn.Close() //nolint: errcheck
+
+	wrapped := connWrapper{proxyproto.NewConn(conn)}
+	_, ok := any(wrapped).(syscall.Conn)
+	require.True(t, ok)
+
+	rawConn, err := wrapped.SyscallConn()
+	require.NoError(t, err)
+	require.NotNil(t, rawConn)
+}

--- a/internal/utils/net_listener.go
+++ b/internal/utils/net_listener.go
@@ -1,9 +1,12 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"syscall"
 
+	"github.com/9seconds/mtg/v2/essentials"
 	"github.com/9seconds/mtg/v2/network"
 )
 
@@ -26,13 +29,22 @@ func (l Listener) Accept() (net.Conn, error) {
 	return conn, nil
 }
 
-func NewListener(bindTo string, bufferSize int) (net.Listener, error) {
-	base, err := net.Listen("tcp", bindTo)
+func NewListener(bindTo string, windowClamp int) (net.Listener, error) {
+	var control func(string, string, syscall.RawConn) error
+	if windowClamp > 0 {
+		control = func(_, _ string, conn syscall.RawConn) error {
+			return essentials.SetRawTCPWindowClamp(conn, windowClamp)
+		}
+	}
+
+	listenConfig := net.ListenConfig{
+		Control: control,
+	}
+
+	base, err := listenConfig.Listen(context.Background(), "tcp", bindTo)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build a base listener: %w", err)
 	}
 
-	return Listener{
-		Listener: base,
-	}, nil
+	return Listener{Listener: base}, nil
 }

--- a/mtglib/proxy.go
+++ b/mtglib/proxy.go
@@ -12,12 +12,15 @@ import (
 	"github.com/9seconds/mtg/v2/essentials"
 	"github.com/9seconds/mtg/v2/mtglib/internal/dc"
 	"github.com/9seconds/mtg/v2/mtglib/internal/doppel"
-	"github.com/9seconds/mtg/v2/mtglib/obfuscation"
 	"github.com/9seconds/mtg/v2/mtglib/internal/relay"
 	"github.com/9seconds/mtg/v2/mtglib/internal/tls"
 	"github.com/9seconds/mtg/v2/mtglib/internal/tls/fake"
+	"github.com/9seconds/mtg/v2/mtglib/obfuscation"
 	"github.com/panjf2000/ants/v2"
 )
+
+// Restore a large receive window after the tiny pre-handshake DPI desync clamp.
+const dpiDesyncPostHandshakeWindowClamp = 1 << 30
 
 // Proxy is an MTPROTO proxy structure.
 type Proxy struct {
@@ -32,6 +35,7 @@ type Proxy struct {
 	domainFrontingPort          int
 	domainFrontingHost          string
 	domainFrontingProxyProtocol bool
+	dpiDesync                   bool
 	workerPool                  *ants.PoolWithFunc
 	telegram                    *dc.Telegram
 	configUpdater               *dc.PublicConfigUpdater
@@ -216,6 +220,12 @@ func (p *Proxy) doFakeTLSHandshake(ctx *streamContext) bool {
 		return false
 	}
 
+	if p.dpiDesync {
+		if err := essentials.SetTCPWindowClamp(ctx.clientConn, dpiDesyncPostHandshakeWindowClamp); err != nil {
+			ctx.logger.DebugError("cannot restore TCP window clamp after handshake", err)
+		}
+	}
+
 	ctx.clientConn = tls.New(ctx.clientConn, true, false)
 
 	return true
@@ -285,7 +295,8 @@ func (p *Proxy) doTelegramCall(ctx *streamContext) error {
 		return fmt.Errorf("cannot parse telegram address %s: %w", foundAddr.Address, err)
 	}
 
-	p.eventStream.Send(ctx,
+	p.eventStream.Send(
+		ctx,
 		NewEventConnectedToDC(ctx.streamID,
 			net.ParseIP(telegramHost),
 			ctx.dc),
@@ -360,6 +371,7 @@ func NewProxy(opts ProxyOpts) (*Proxy, error) {
 		logger:                   logger,
 		domainFrontingPort:       opts.getDomainFrontingPort(),
 		domainFrontingHost:       opts.DomainFrontingHost,
+		dpiDesync:                opts.DPIDesync,
 		tolerateTimeSkewness:     opts.getTolerateTimeSkewness(),
 		idleTimeout:              opts.getIdleTimeout(),
 		handshakeTimeout:         opts.getHandshakeTimeout(),

--- a/mtglib/proxy_opts.go
+++ b/mtglib/proxy_opts.go
@@ -177,6 +177,10 @@ type ProxyOpts struct {
 
 	// DoppelGangerDRS defines if TLS Dynamic Record Sizing is active.
 	DoppelGangerDRS bool
+
+	// DPIDesync enables post-handshake TCP window restore. Callers that set it
+	// must also apply the pre-handshake window clamp on accepted client sockets.
+	DPIDesync bool
 }
 
 func (p ProxyOpts) valid() error {


### PR DESCRIPTION
## Summary
- add opt-in `dpi-desync` mode for Linux IPv4 FakeTLS handshakes
- clamp the client TCP receive window during the handshake, inject an invalid-checksum TLS alert for DPI desync, and restore the window after FakeTLS succeeds
- expose the option in config and simple-run, document CAP_NET_RAW requirements, and keep PROXY protocol sockets compatible with post-handshake clamp restore

## Why
Some DPI deployments appear to classify and block Telegram/FakeTLS connections by the TLS ClientHello JA4/JA4+ fingerprint before MTProto can start. This mode does not change the client fingerprint. Instead, it desynchronizes the DPI TCP view from the real endpoint: DPI can observe an early TLS alert, while the real client drops the injected packet and continues the normal FakeTLS handshake.

## Notes
- disabled by default
- Linux IPv4 only
- requires root or CAP_NET_RAW because it opens raw packet sockets
- the pre-handshake TCP_WINDOW_CLAMP value is intentionally fixed at 256: in testing it was small enough for desync to work while still allowing Telegram media after the post-handshake window restore

## Test plan
- `git diff --check`
- `gofumpt -l --extra ...`
- `go test ./...`
- `go test -race ./internal/desync ./internal/proxyprotocol ./internal/config ./internal/cli ./mtglib`
- `golangci-lint run ./...`